### PR TITLE
Added support for local mounts

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20.x'
+          go-version: '1.21.x'
           cache: false
 
       - name: golangci-lint
@@ -44,7 +44,7 @@ jobs:
           # Require: The version of golangci-lint to use.
           # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.
           # When `install-mode` is `goinstall` the value can be v1.2.3, `latest`, or the hash of a commit.
-          version: v1.53
+          version: v1.54
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/README.md
+++ b/README.md
@@ -134,8 +134,9 @@ tasks:
     image: jrottenberg/ffmpeg:3.4-alpine
     run: |
       ffmpeg -i /tmp/input.ogv -t 5 /tmp/output.mp4
-    volumes:
-      - /tmp
+    mounts:
+      - type: volume
+        target: /tmp
     pre:
       - name: download the remote file
         image: alpine:3.18.3

--- a/configs/sample.config.toml
+++ b/configs/sample.config.toml
@@ -71,6 +71,13 @@ enabled = false
 address = "localhost:8001"
 tempdir = "/tmp"
 
+# default task limits
 [worker.limits]
-cpus = "1"
-memory = "100"
+cpus = ""   # supports fractions
+memory = "" # e.g. 100m 
+
+
+[worker.mounts.bind]
+allowed = false
+allowlist = []  # supports wildcards (*)
+denylist = []   # supports wildcards (*)

--- a/db/postgres/schema.go
+++ b/db/postgres/schema.go
@@ -71,7 +71,7 @@ CREATE TABLE tasks (
     error_        text,
     pre_tasks     jsonb,
     post_tasks    jsonb,
-    volumes       text[],
+    mounts       jsonb,
     node_id       varchar(32),
     retry         jsonb,
     limits        jsonb,

--- a/engine/worker.go
+++ b/engine/worker.go
@@ -23,6 +23,11 @@ func (e *Engine) initWorker() error {
 		},
 		TempDir: conf.String("worker.tempdir"),
 		Address: conf.String("worker.address"),
+		BindMounts: worker.Mounts{
+			Allowed:   conf.Bool("worker.mounts.bind.allowed"),
+			Allowlist: conf.Strings("worker.mounts.bind.allowlist"),
+			Denylist:  conf.Strings("worker.mounts.bind.denylist"),
+		},
 	})
 	if err != nil {
 		return errors.Wrapf(err, "error creating worker")

--- a/examples/aws_create_master.yaml
+++ b/examples/aws_create_master.yaml
@@ -18,5 +18,6 @@ tasks:
         image: amazon/aws-cli:2.13.10
         env:
           BUCKET_NAME: my-bucket
-    volumes:
-      - /tmp
+    mounts:
+      - type: volume
+        target: /tmp

--- a/examples/aws_split_and_stitch.yaml
+++ b/examples/aws_split_and_stitch.yaml
@@ -127,8 +127,9 @@ tasks:
               BUCKET_NAME: "{{inputs.bucket}}"
               FOLDER_NAME: "{{tasks.folderName}}"
               NUMBER: "{{ item.index }}"
-        volumes:
-          - /tmp
+        mounts:
+          - type: volume
+            target: /tmp
         retry:
           limit: 2
         timeout: 180s
@@ -156,7 +157,8 @@ tasks:
         env:
           BUCKET_NAME: "{{inputs.bucket}}"
           FOLDER_NAME: "{{tasks.folderName}}"
-    volumes:
-      - /tmp
+    mounts:
+      - type: volume
+        target: /tmp
     retry:
       limit: 2

--- a/examples/hls.yaml
+++ b/examples/hls.yaml
@@ -57,8 +57,9 @@ tasks:
         - name: Generate 360p HLS stream
           retry: 
             limit: 2
-          volumes:
-            - /tmp
+          mounts:
+            - type: volume
+              target: /tmp
           networks:
             - minio
           run: |
@@ -83,8 +84,9 @@ tasks:
         - name: Generate 480p HLS stream
           retry: 
             limit: 2
-          volumes:
-            - /tmp
+          mounts:
+            - type: volume
+              target: /tmp
           networks:
             - minio
           run: |
@@ -109,8 +111,9 @@ tasks:
         - name: Generate 720p HLS stream
           retry: 
             limit: 2
-          volumes:
-            - /tmp
+          mounts:
+            - type: volume
+              target: /tmp
           networks:
             - minio
           run: |

--- a/examples/resize_image.yaml
+++ b/examples/resize_image.yaml
@@ -36,8 +36,9 @@ tasks:
       list: "{{ ['1920x1080','1366x768','1280x720','768x1024','100x100','200x200'] }}"
       task:
         name: 'Scale the image to {{ item.value }}'
-        volumes:
-          - /workdir
+        mounts:
+          - type: volume
+            target: /workdir
         networks:
           - minio
         image: dpokidov/imagemagick

--- a/examples/split_and_stitch.yaml
+++ b/examples/split_and_stitch.yaml
@@ -155,8 +155,9 @@ tasks:
               BUCKET_NAME: "{{tasks.bucketName}}"
               ENDPOINT_URL: "{{inputs.endpointURL}}"
               NUMBER: "{{ item.index }}"
-        volumes:
-          - /tmp
+        mounts:
+          - type: volume
+            target: /tmp
         retry:
           limit: 2
 
@@ -187,8 +188,9 @@ tasks:
           AWS_SECRET_ACCESS_KEY: "{{inputs.secretKeyID}}"
           BUCKET_NAME: "{{tasks.bucketName}}"
           ENDPOINT_URL: "{{inputs.endpointURL}}"
-    volumes:
-      - /tmp
+    mounts:
+      - type: volume
+        target: /tmp
     retry:
       limit: 2
     timeout: 120s

--- a/input/task.go
+++ b/input/task.go
@@ -18,7 +18,7 @@ type Task struct {
 	Queue       string            `json:"queue,omitempty" yaml:"queue,omitempty" validate:"queue"`
 	Pre         []AuxTask         `json:"pre,omitempty" yaml:"pre,omitempty" validate:"dive"`
 	Post        []AuxTask         `json:"post,omitempty" yaml:"post,omitempty" validate:"dive"`
-	Volumes     []string          `json:"volumes,omitempty" yaml:"volumes,omitempty"`
+	Mounts      []Mount           `json:"mounts,omitempty" yaml:"mounts,omitempty" validate:"dive"`
 	Networks    []string          `json:"networks,omitempty" yaml:"networks,omitempty"`
 	Retry       *Retry            `json:"retry,omitempty" yaml:"retry,omitempty"`
 	Limits      *Limits           `json:"limits,omitempty" yaml:"limits,omitempty"`
@@ -28,6 +28,11 @@ type Task struct {
 	Parallel    *Parallel         `json:"parallel,omitempty" yaml:"parallel,omitempty"`
 	Each        *Each             `json:"each,omitempty" yaml:"each,omitempty"`
 	SubJob      *SubJob           `json:"subjob,omitempty" yaml:"subjob,omitempty"`
+}
+type Mount struct {
+	Type   string `json:"type,omitempty" yaml:"type,omitempty"`
+	Source string `json:"source,omitempty" yaml:"source,omitempty"`
+	Target string `json:"target,omitempty" yaml:"target,omitempty"`
 }
 
 type AuxTask struct {
@@ -40,6 +45,14 @@ type AuxTask struct {
 	Registry    *Registry         `json:"registry,omitempty" yaml:"registry,omitempty"`
 	Env         map[string]string `json:"env,omitempty" yaml:"env,omitempty"`
 	Timeout     string            `json:"timeout,omitempty" yaml:"timeout,omitempty"`
+}
+
+func (m Mount) toMount() tork.Mount {
+	return tork.Mount{
+		Type:   m.Type,
+		Source: m.Source,
+		Target: m.Target,
+	}
 }
 
 func (i AuxTask) toTask() *tork.Task {
@@ -117,7 +130,7 @@ func (i Task) toTask() *tork.Task {
 		Queue:       i.Queue,
 		Pre:         pre,
 		Post:        post,
-		Volumes:     i.Volumes,
+		Mounts:      toMounts(i.Mounts),
 		Networks:    i.Networks,
 		Retry:       retry,
 		Limits:      limits,
@@ -128,6 +141,14 @@ func (i Task) toTask() *tork.Task {
 		Each:        each,
 		SubJob:      subjob,
 	}
+}
+
+func toMounts(ms []Mount) []tork.Mount {
+	result := make([]tork.Mount, len(ms))
+	for i, m := range ms {
+		result[i] = m.toMount()
+	}
+	return result
 }
 
 func toAuxTasks(tis []AuxTask) []*tork.Task {

--- a/input/validate_test.go
+++ b/input/validate_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/go-playground/validator/v10"
+	"github.com/runabol/tork"
 	"github.com/runabol/tork/mq"
 	"github.com/stretchr/testify/assert"
 )
@@ -326,6 +327,165 @@ func TestValidateExpr(t *testing.T) {
 					Task: Task{
 						Name:  "test task",
 						Image: "some:image",
+					},
+				},
+			},
+		},
+	}
+	err = j.Validate()
+	assert.Error(t, err)
+}
+
+func TestValidateMounts(t *testing.T) {
+	j := Job{
+		Name: "test job",
+		Tasks: []Task{
+			{
+				Name:  "test task",
+				Image: "some:image",
+				Run:   "some script",
+				Mounts: []Mount{
+					{
+						Type:   "", // missing
+						Target: "", // missing
+					},
+				},
+			},
+		},
+	}
+	err := j.Validate()
+	assert.Error(t, err)
+
+	j = Job{
+		Name: "test job",
+		Tasks: []Task{
+			{
+				Name:  "test task",
+				Image: "some:image",
+				Run:   "some script",
+				Mounts: []Mount{
+					{
+						Type:   tork.MountTypeVolume,
+						Target: "/some/target",
+					},
+				},
+			},
+		},
+	}
+	err = j.Validate()
+	assert.NoError(t, err)
+
+	j = Job{
+		Name: "test job",
+		Tasks: []Task{
+			{
+				Name:  "test task",
+				Image: "some:image",
+				Run:   "some script",
+				Mounts: []Mount{
+					{
+						Type:   "bad type",
+						Target: "/some/target",
+					},
+				},
+			},
+		},
+	}
+	err = j.Validate()
+	assert.Error(t, err)
+
+	j = Job{
+		Name: "test job",
+		Tasks: []Task{
+			{
+				Name:  "test task",
+				Image: "some:image",
+				Run:   "some script",
+				Mounts: []Mount{
+					{
+						Type:   tork.MountTypeBind,
+						Source: "", // missing
+						Target: "/some/target",
+					},
+				},
+			},
+		},
+	}
+	err = j.Validate()
+	assert.Error(t, err)
+
+	j = Job{
+		Name: "test job",
+		Tasks: []Task{
+			{
+				Name:  "test task",
+				Image: "some:image",
+				Run:   "some script",
+				Mounts: []Mount{
+					{
+						Type:   tork.MountTypeBind,
+						Source: "/some/source",
+						Target: "/some/target",
+					},
+				},
+			},
+		},
+	}
+	err = j.Validate()
+	assert.NoError(t, err)
+
+	j = Job{
+		Name: "test job",
+		Tasks: []Task{
+			{
+				Name:  "test task",
+				Image: "some:image",
+				Run:   "some script",
+				Mounts: []Mount{
+					{
+						Type:   tork.MountTypeBind,
+						Source: "../some/source", // invalid
+						Target: "/some/target",
+					},
+				},
+			},
+		},
+	}
+	err = j.Validate()
+	assert.Error(t, err)
+
+	j = Job{
+		Name: "test job",
+		Tasks: []Task{
+			{
+				Name:  "test task",
+				Image: "some:image",
+				Run:   "some script",
+				Mounts: []Mount{
+					{
+						Type:   tork.MountTypeBind,
+						Source: "/some#/source", // invalid
+						Target: "/some/target",
+					},
+				},
+			},
+		},
+	}
+	err = j.Validate()
+	assert.Error(t, err)
+
+	j = Job{
+		Name: "test job",
+		Tasks: []Task{
+			{
+				Name:  "test task",
+				Image: "some:image",
+				Run:   "some script",
+				Mounts: []Mount{
+					{
+						Type:   tork.MountTypeBind,
+						Source: "/some/source",
+						Target: "/some:/target", // invalid
 					},
 				},
 			},

--- a/internal/coordinator/coordinator.go
+++ b/internal/coordinator/coordinator.go
@@ -184,33 +184,27 @@ func (c *Coordinator) Start() error {
 			switch qname {
 			case mq.QUEUE_PENDING:
 				err = c.broker.SubscribeForTasks(qname, func(t *tork.Task) error {
-					ctx := context.Background()
-					return c.onPending(ctx, t)
+					return c.onPending(context.Background(), t)
 				})
 			case mq.QUEUE_COMPLETED:
 				err = c.broker.SubscribeForTasks(qname, func(t *tork.Task) error {
-					ctx := context.Background()
-					return c.onCompleted(ctx, t)
+					return c.onCompleted(context.Background(), t)
 				})
 			case mq.QUEUE_STARTED:
 				err = c.broker.SubscribeForTasks(qname, func(t *tork.Task) error {
-					ctx := context.Background()
-					return c.onStarted(ctx, t)
+					return c.onStarted(context.Background(), t)
 				})
 			case mq.QUEUE_ERROR:
 				err = c.broker.SubscribeForTasks(qname, func(t *tork.Task) error {
-					ctx := context.Background()
-					return c.onError(ctx, t)
+					return c.onError(context.Background(), t)
 				})
 			case mq.QUEUE_HEARBEAT:
 				err = c.broker.SubscribeForHeartbeats(func(n *tork.Node) error {
-					ctx := context.Background()
-					return c.onHeartbeat(ctx, n)
+					return c.onHeartbeat(context.Background(), n)
 				})
 			case mq.QUEUE_JOBS:
 				err = c.broker.SubscribeForJobs(func(j *tork.Job) error {
-					ctx := context.Background()
-					return c.onJob(ctx, job.StateChange, j)
+					return c.onJob(context.Background(), job.StateChange, j)
 				})
 			}
 			if err != nil {

--- a/internal/coordinator/coordinator_test.go
+++ b/internal/coordinator/coordinator_test.go
@@ -76,9 +76,7 @@ func TestTaskMiddlewareWithError(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.NotNil(t, c)
-
-	tk := &tork.Task{}
-	assert.ErrorIs(t, c.onPending(context.Background(), tk), Err)
+	assert.ErrorIs(t, c.onPending(context.Background(), &tork.Task{}), Err)
 }
 
 func TestTaskMiddlewareNoOp(t *testing.T) {
@@ -166,8 +164,7 @@ func TestJobMiddlewareWithError(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, c)
 
-	j := &tork.Job{}
-	assert.ErrorIs(t, c.onJob(context.Background(), job.StateChange, j), Err)
+	assert.ErrorIs(t, c.onJob(context.Background(), job.StateChange, &tork.Job{}), Err)
 }
 
 func TestJobMiddlewareNoOp(t *testing.T) {

--- a/mq/inmemory_test.go
+++ b/mq/inmemory_test.go
@@ -24,13 +24,18 @@ func TestInMemoryPublishAndSubsribeForTask(t *testing.T) {
 	assert.NoError(t, err)
 
 	t1 := &tork.Task{
-		ID:      uuid.NewUUID(),
-		Volumes: []string{"/somevolume"},
+		ID: uuid.NewUUID(),
+		Mounts: []tork.Mount{
+			{
+				Type:   tork.MountTypeVolume,
+				Target: "/somevolume",
+			},
+		},
 	}
 	err = b.PublishTask(ctx, "test-queue", t1)
 	<-processed
 	assert.NoError(t, err)
-	assert.Equal(t, []string{"/somevolume"}, t1.Volumes)
+	assert.Equal(t, "/somevolume", t1.Mounts[0].Target)
 }
 
 func TestInMemoryGetQueues(t *testing.T) {

--- a/mq/rabbitmq_test.go
+++ b/mq/rabbitmq_test.go
@@ -17,18 +17,16 @@ func TestRabbitMQPublishAndSubsribeForTask(t *testing.T) {
 	ctx := context.Background()
 	b, err := mq.NewRabbitMQBroker("amqp://guest:guest@localhost:5672/")
 	assert.NoError(t, err)
-	processed := 0
+	processed := make(chan any)
 	qname := fmt.Sprintf("%stest-%s", mq.QUEUE_EXCLUSIVE_PREFIX, uuid.NewUUID())
 	err = b.SubscribeForTasks(qname, func(t *tork.Task) error {
-		processed = processed + 1
+		processed <- 1
 		return nil
 	})
 	assert.NoError(t, err)
 	err = b.PublishTask(ctx, qname, &tork.Task{})
-	// wait for task to be processed
-	time.Sleep(time.Millisecond * 500)
+	<-processed
 	assert.NoError(t, err)
-	assert.Equal(t, 1, processed)
 }
 
 func TestRabbitMQGetQueues(t *testing.T) {

--- a/runtime/docker_test.go
+++ b/runtime/docker_test.go
@@ -2,7 +2,6 @@ package runtime
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path"
 	"sync"
@@ -205,9 +204,17 @@ func TestRunTaskWithVolume(t *testing.T) {
 		ID:    uuid.NewUUID(),
 		Image: "ubuntu:mantic",
 		Run:   "-",
-		Volumes: []string{
-			fmt.Sprintf("volume:%s:%s", vname, "/xyz"),
-			fmt.Sprintf("bind:%s:%s", rundir, "/tork"),
+		Mounts: []tork.Mount{
+			{
+				Type:   tork.MountTypeVolume,
+				Source: vname,
+				Target: "/xyz",
+			},
+			{
+				Type:   tork.MountTypeBind,
+				Source: rundir,
+				Target: "/tork",
+			},
 		},
 	}
 	err = rt.Run(ctx, t1)

--- a/task.go
+++ b/task.go
@@ -1,6 +1,7 @@
 package tork
 
 import (
+	"slices"
 	"time"
 
 	"golang.org/x/exp/maps"
@@ -18,6 +19,9 @@ const (
 	TaskStateStopped   TaskState = "STOPPED"
 	TaskStateCompleted TaskState = "COMPLETED"
 	TaskStateFailed    TaskState = "FAILED"
+
+	MountTypeVolume string = "volume"
+	MountTypeBind   string = "bind"
 )
 
 // Task is the basic unit of work that a Worker can handle.
@@ -45,7 +49,7 @@ type Task struct {
 	Error       string            `json:"error,omitempty"`
 	Pre         []*Task           `json:"pre,omitempty"`
 	Post        []*Task           `json:"post,omitempty"`
-	Volumes     []string          `json:"volumes,omitempty"`
+	Mounts      []Mount           `json:"mounts,omitempty"`
 	Networks    []string          `json:"networks,omitempty"`
 	NodeID      string            `json:"nodeId,omitempty"`
 	Retry       *TaskRetry        `json:"retry,omitempty"`
@@ -57,6 +61,12 @@ type Task struct {
 	Parallel    *ParallelTask     `json:"parallel,omitempty"`
 	Each        *EachTask         `json:"each,omitempty"`
 	SubJob      *SubJobTask       `json:"subjob,omitempty"`
+}
+
+type Mount struct {
+	Type   string `json:"type,omitempty"`
+	Source string `json:"source,omitempty"`
+	Target string `json:"target,omitempty"`
 }
 
 type SubJobTask struct {
@@ -149,7 +159,7 @@ func (t *Task) Clone() *Task {
 		Error:       t.Error,
 		Pre:         CloneTasks(t.Pre),
 		Post:        CloneTasks(t.Post),
-		Volumes:     t.Volumes,
+		Mounts:      slices.Clone(t.Mounts),
 		Networks:    t.Networks,
 		NodeID:      t.NodeID,
 		Retry:       retry,


### PR DESCRIPTION
This PR adds support for local mounts. 

The implementation extends the existing ability to specify volumes. to share state between the task and its `pre` and `post` tasks. e.g.: 

```yaml
name: my task
image: some:image
volumes:
  - /myvolume
``` 

To specify a local mount the job author will use the following syntax: 

```yaml
name: my task
image: some:image
volumes:
  - /some/local/dir:/target/mount
``` 

Also, 
* `worker.mounts.enabled` must be set to `true` in the worker configs (it's `false` by default)
* the mount point **not** appearing in the `worker.mounts.denylist` patterns  
* the mount **is** appearing in the `worker.mounts.allowlist`