### PR TITLE
fix tork-web internal port in docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -34,7 +34,7 @@ services:
     platform: linux/amd64
     restart: always
     ports:
-      - 8100:3000
+      - 8100:8100
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:


### PR DESCRIPTION
After tork-web port changes this docker-compose file has to be fixed also
relates to this commit:
https://github.com/runabol/tork-web/commit/ebd37c9a74e28a91c49577d79ce1f48a0fb32ec8