### PR TITLE
Added the ability to configure the consumer timeout

### DIFF
--- a/conf/conf.go
+++ b/conf/conf.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/knadh/koanf/parsers/toml"
 	"github.com/knadh/koanf/providers/env"
@@ -78,6 +79,14 @@ func StringMap(key string) map[string]string {
 
 func Strings(key string) []string {
 	return konf.Strings(key)
+}
+
+func DurationDefault(key string, dv time.Duration) time.Duration {
+	v := konf.Get(key)
+	if v == nil {
+		return dv
+	}
+	return konf.Duration(key)
 }
 
 func StringsDefault(key string, dv []string) []string {

--- a/conf/conf_test.go
+++ b/conf/conf_test.go
@@ -3,6 +3,7 @@ package conf_test
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/runabol/tork/conf"
 	"github.com/stretchr/testify/assert"
@@ -160,6 +161,23 @@ func TestBoolDefault(t *testing.T) {
 	assert.False(t, conf.BoolDefault("main.enabled", true))
 	assert.False(t, conf.BoolDefault("main.enabled", false))
 	assert.True(t, conf.BoolDefault("main.other", true))
+}
+
+func TestDurationDefault(t *testing.T) {
+	konf := `
+	[main]
+	some.duration = "5m"
+	`
+	err := os.WriteFile("config.toml", []byte(konf), os.ModePerm)
+	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, os.Remove("config.toml"))
+	}()
+	err = conf.LoadConfig()
+
+	assert.NoError(t, err)
+	assert.Equal(t, time.Minute*5, conf.DurationDefault("main.some.duration", time.Minute))
+	assert.Equal(t, time.Minute, conf.DurationDefault("main.other.duration", time.Minute))
 }
 
 func TestBoolMap(t *testing.T) {

--- a/configs/sample.config.toml
+++ b/configs/sample.config.toml
@@ -13,6 +13,7 @@ type = "inmemory" # inmemory | rabbitmq
 
 [broker.rabbitmq]
 url = "amqp://guest:guest@localhost:5672/"
+consumer.timeout = "30m"
 
 [datastore]
 type = "inmemory" # inmemory | postgres

--- a/engine/broker.go
+++ b/engine/broker.go
@@ -25,7 +25,10 @@ func (e *Engine) createBroker(btype string) (mq.Broker, error) {
 	case "inmemory":
 		return mq.NewInMemoryBroker(), nil
 	case "rabbitmq":
-		rb, err := mq.NewRabbitMQBroker(conf.StringDefault("broker.rabbitmq.url", "amqp://guest:guest@localhost:5672/"))
+		rb, err := mq.NewRabbitMQBroker(
+			conf.StringDefault("broker.rabbitmq.url", "amqp://guest:guest@localhost:5672/"),
+			mq.WithConsumerTimeoutMS(conf.DurationDefault("broker.rabbitmq.consumer.timeout", mq.RABBITMQ_DEFAULT_CONSUMER_TIMEOUT)),
+		)
 		if err != nil {
 			return nil, errors.Wrapf(err, "unable to connect to RabbitMQ")
 		}

--- a/runtime/docker/docker_test.go
+++ b/runtime/docker/docker_test.go
@@ -213,7 +213,7 @@ func Test_imagePull(t *testing.T) {
 	assert.NotNil(t, rt)
 
 	images, err := rt.client.ImageList(ctx, types.ImageListOptions{
-		Filters: filters.NewArgs(filters.Arg("reference", "alpine:*")),
+		Filters: filters.NewArgs(filters.Arg("reference", "busybox:*")),
 	})
 	assert.NoError(t, err)
 
@@ -231,7 +231,7 @@ func Test_imagePull(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		go func() {
 			defer wg.Done()
-			err := rt.imagePull(ctx, &tork.Task{Image: "alpine:3.18.3"})
+			err := rt.imagePull(ctx, &tork.Task{Image: "busybox:1.36"})
 			assert.NoError(t, err)
 		}()
 	}


### PR DESCRIPTION
From the RabbitMQ docs:

> RabbitMQ enforces a timeout is enforced on consumer delivery acknowledgement. This is a protection mechanism that helps detect buggy (stuck) consumers that never acknowledge deliveries. Such consumers can affect node's on disk data compaction and potentially drive nodes out of disk space.

> If a consumer does not ack its delivery for more than the timeout value **(30 minutes by default)***, its channel will be closed with a `PRECONDITION_FAILED` channel exception.

For certain use case (see https://github.com/runabol/tork/issues/208) the default 30 minutes timeout is not enough. 

This PR introduces a new config property: `broker.rabbitmq.consumer.timeout` to allow Tork administrators to configure the consumer timeout. For example: `broker.rabbitmq.consumer.timeout = "60m"` will configure the timeout to 60 minutes.