### PR TITLE
Fixed remove volume bug

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -28,7 +28,7 @@ services:
     image: registry:2
     restart: always
     ports:
-      - 5000:5000
+      - 5001:5001
   web:
     image: runabol/tork-web
     platform: linux/amd64

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -248,6 +248,9 @@ func (d *DockerRuntime) doRun(ctx context.Context, t *tork.Task) error {
 		return err
 	}
 
+	// create a mapping between task id and container id
+	d.tasks.Set(t.ID, resp.ID)
+
 	log.Debug().Msgf("created container %s", resp.ID)
 
 	// remove the container
@@ -266,9 +269,6 @@ func (d *DockerRuntime) doRun(ctx context.Context, t *tork.Task) error {
 	if err := d.initWorkdir(ctx, resp.ID, t); err != nil {
 		return errors.Wrapf(err, "error initializing container")
 	}
-
-	// create a mapping between task id and container id
-	d.tasks.Set(t.ID, resp.ID)
 
 	// start the container
 	log.Debug().Msgf("Starting container %s", resp.ID)
@@ -472,7 +472,7 @@ func (d *DockerRuntime) Stop(ctx context.Context, t *tork.Task) error {
 		return nil
 	}
 	d.tasks.Delete(t.ID)
-	log.Printf("Attempting to stop and remove container %v", containerID)
+	log.Debug().Msgf("Attempting to stop and remove container %v", containerID)
 	return d.client.ContainerRemove(ctx, containerID, types.ContainerRemoveOptions{
 		RemoveVolumes: true,
 		RemoveLinks:   false,


### PR DESCRIPTION
Error message:

```
Error response from daemon: remove aa16c17221124040986e1f432f3ae74e: volume is in use - [80106858a623d44b43e5640d34289eb22a0c6eb3bedb6b223f22f84aa92b0c24]
```

The root cause was not tracking the container ID after it was created but rather after it was started. 

This led to not deleting the volumes and the container when the task exited if the container never actually started.