### PR TITLE
Coordinator heartbeat and node name

### DIFF
--- a/configs/sample.config.toml
+++ b/configs/sample.config.toml
@@ -24,6 +24,7 @@ dsn = "host=localhost user=tork password=tork dbname=tork port=5432 sslmode=disa
 
 [coordinator]
 address = "localhost:8000"
+name = "Coordinator"
 
 [coordinator.api]
 endpoints.health = true  # turn on|off the /health endpoint
@@ -76,6 +77,7 @@ vars = [
 
 [worker]
 address = "localhost:8001"
+name = "Worker"
 
 # default task limits
 [worker.limits]

--- a/datastore/postgres.go
+++ b/datastore/postgres.go
@@ -83,6 +83,7 @@ type jobRecord struct {
 
 type nodeRecord struct {
 	ID              string    `db:"id"`
+	Name            string    `db:"name"`
 	StartedAt       time.Time `db:"started_at"`
 	LastHeartbeatAt time.Time `db:"last_heartbeat_at"`
 	CPUPercent      float64   `db:"cpu_percent"`
@@ -207,6 +208,7 @@ func (r taskRecord) toTask() (*tork.Task, error) {
 func (r nodeRecord) toNode() *tork.Node {
 	n := tork.Node{
 		ID:              r.ID,
+		Name:            r.Name,
 		StartedAt:       r.StartedAt,
 		CPUPercent:      r.CPUPercent,
 		LastHeartbeatAt: r.LastHeartbeatAt,
@@ -576,10 +578,10 @@ func (ds *PostgresDatastore) UpdateTask(ctx context.Context, id string, modify f
 
 func (ds *PostgresDatastore) CreateNode(ctx context.Context, n *tork.Node) error {
 	q := `insert into nodes 
-	       (id,started_at,last_heartbeat_at,cpu_percent,queue,status,hostname,task_count,version_) 
+	       (id,name,started_at,last_heartbeat_at,cpu_percent,queue,status,hostname,task_count,version_) 
 	      values
-	       ($1,$2,$3,$4,$5,$6,$7,$8,$9)`
-	_, err := ds.exec(q, n.ID, n.StartedAt, n.LastHeartbeatAt, n.CPUPercent, n.Queue, n.Status, n.Hostname, n.TaskCount, n.Version)
+	       ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`
+	_, err := ds.exec(q, n.ID, n.Name, n.StartedAt, n.LastHeartbeatAt, n.CPUPercent, n.Queue, n.Status, n.Hostname, n.TaskCount, n.Version)
 	if err != nil {
 		return errors.Wrapf(err, "error inserting node to the db")
 	}

--- a/datastore/postgres_test.go
+++ b/datastore/postgres_test.go
@@ -279,6 +279,7 @@ func TestPostgresCreateAndGetNode(t *testing.T) {
 	assert.NoError(t, err)
 	n1 := &tork.Node{
 		ID:       uuid.NewUUID(),
+		Name:     "some node",
 		Hostname: "some-name",
 		Version:  "1.0.0",
 	}
@@ -289,6 +290,7 @@ func TestPostgresCreateAndGetNode(t *testing.T) {
 	assert.Equal(t, n1.ID, n2.ID)
 	assert.Equal(t, "some-name", n2.Hostname)
 	assert.Equal(t, "1.0.0", n2.Version)
+	assert.Equal(t, "some node", n2.Name)
 }
 
 func TestPostgresUpdateNode(t *testing.T) {

--- a/db/postgres/schema.go
+++ b/db/postgres/schema.go
@@ -3,6 +3,7 @@ package postgres
 const SCHEMA = `
 CREATE TABLE nodes (
     id                 varchar(32)  not null primary key,
+    name               varchar(64)  not null,
     queue              varchar(64)  not null,
     started_at         timestamp    not null,
     last_heartbeat_at  timestamp    not null,

--- a/engine/coordinator.go
+++ b/engine/coordinator.go
@@ -23,6 +23,7 @@ func (e *Engine) initCoordinator() error {
 	queues := conf.IntMap("coordinator.queues")
 
 	cfg := coordinator.Config{
+		Name:      conf.StringDefault("coordinator.name", "Coordinator"),
 		Broker:    e.broker,
 		DataStore: e.ds,
 		Queues:    queues,

--- a/engine/worker.go
+++ b/engine/worker.go
@@ -24,6 +24,7 @@ func (e *Engine) initWorker() error {
 	}
 	e.cfg.Middleware.Task = append(e.cfg.Middleware.Task, hostenv.Execute)
 	w, err := worker.NewWorker(worker.Config{
+		Name:    conf.StringDefault("worker.name", "Worker"),
 		Broker:  e.broker,
 		Runtime: rt,
 		Queues:  conf.IntMap("worker.queues"),

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -1,11 +1,11 @@
-package worker
+package host
 
 import (
 	"github.com/rs/zerolog/log"
 	"github.com/shirou/gopsutil/v3/cpu"
 )
 
-func getCPUPercent() float64 {
+func GetCPUPercent() float64 {
 	perc, err := cpu.Percent(0, false)
 	if err != nil {
 		log.Warn().

--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -1,4 +1,4 @@
-package worker
+package host
 
 import (
 	"testing"
@@ -7,6 +7,6 @@ import (
 )
 
 func TestGetStats(t *testing.T) {
-	cpuPercent := getCPUPercent()
+	cpuPercent := GetCPUPercent()
 	assert.GreaterOrEqual(t, cpuPercent, float64(0))
 }

--- a/node.go
+++ b/node.go
@@ -17,19 +17,21 @@ const (
 
 type Node struct {
 	ID              string     `json:"id,omitempty"`
+	Name            string     `json:"name,omitempty"`
 	StartedAt       time.Time  `json:"startedAt,omitempty"`
 	CPUPercent      float64    `json:"cpuPercent,omitempty"`
 	LastHeartbeatAt time.Time  `json:"lastHeartbeatAt,omitempty"`
 	Queue           string     `json:"queue,omitempty"`
 	Status          NodeStatus `json:"status,omitempty"`
 	Hostname        string     `json:"hostname,omitempty"`
-	TaskCount       int        `json:"taskCount"`
+	TaskCount       int        `json:"taskCount,omitempty"`
 	Version         string     `json:"version"`
 }
 
 func (n *Node) Clone() *Node {
 	return &Node{
 		ID:              n.ID,
+		Name:            n.Name,
 		StartedAt:       n.StartedAt,
 		CPUPercent:      n.CPUPercent,
 		LastHeartbeatAt: n.LastHeartbeatAt,


### PR DESCRIPTION
This PR:

1. Adds support for coordinator heartbeats so coordinators are listed in the `/nodes` endpoint.
2. Adds support for configurable node names. 