### PR TITLE
Add support for release-drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,69 @@
+name-template: '$RESOLVED_VERSION'
+tag-template: '$RESOLVED_VERSION'
+categories:
+  - title: '🔒 Security:'
+    labels:
+      - '🔒 Security'
+  - title: '❗ Breaking Changes:'
+    labels:
+      - '❗ Breaking Change'
+  - title: '🚀 Features:'
+    labels:
+      - '✏️ Feature'
+  - title: '🐛 Bug Fixes:'
+    labels:
+      - '🐛 Bug'
+  - title: '📚 Documentation:'
+    labels:
+      - '📒 Documentation'
+  - title: '🧹 Updates:'
+    labels:
+      - '🧹 Updates'
+      - '🤖 Dependencies'
+change-template: '- $TITLE (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+exclude-contributors:
+  - dependabot
+  - dependabot[bot]
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+      - '❗ Breaking Change'
+  patch:
+    labels:
+      - '✏️ Feature'
+      - '📒 Documentation'
+      - '🐛 Bug'
+      - '🤖 Dependencies'
+      - '🧹 Updates'
+      - '🔒 Security'
+  default: patch
+template: |
+    $CHANGES
+
+    **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...$RESOLVED_VERSION
+
+    Thanks to $CONTRIBUTORS for making this release possible.
+
+autolabeler:
+- label: '📒 Documentation'
+  files:
+    - '*.md'
+  title:
+    - '/(docs|doc:|\[doc\]|typos|comment|documentation)/i'
+- label: '🐛 Bug'
+  title:
+    - '/(fix|race|bug|missing|correct)/i'
+- label: '🧹 Updates'
+  title: 
+    - '/(improve|update|update|refactor|deprecated|remove|unused|test)/i'
+- label: '🤖 Dependencies'
+  title:
+    - '/(bump|dependencies)/i'
+- label: '✏️ Feature'
+  title:
+    - '/(feature|feat|create|implement|add)/i'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,22 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes #233 

@runabol How do you want to handle `minor` and `major` tags? Release drafter will auto-generate the tag based on the labels of the PR's that have been merged.

```yaml
version-resolver:
  major:
    labels:
      - 'major'
  minor:
    labels:
      - 'minor'
      - '❗ Breaking Change'
  patch:
    labels:
      - '✏️ Feature'
      - '📒 Documentation'
      - '🐛 Bug'
      - '🤖 Dependencies'
      - '🧹 Updates'
      - '🔒 Security'
```

In my initial draft, I have left both `major`  and `minor` as place holders. All the other labels will increment the `patch` release. Do you want to move some of those or add new ones to manage the `minor` releases?