### PR TITLE
Feature: Key Auth

### DIFF
--- a/configs/sample.config.toml
+++ b/configs/sample.config.toml
@@ -57,6 +57,11 @@ enabled = false
 username = "tork"
 password = ""     # if left blank, it will auto-generate a password and print it to the logs on startup
 
+[middleware.web.keyauth]
+enabled = false
+key = ""        # if left blank, it will auto-generate a key and print it to the logs on startup
+
+
 # rate limiter middleware
 [middleware.web.ratelimit]
 enabled = false


### PR DESCRIPTION
Adds support for key-based authorization:

e.g.

```
curl -H "Authorization: Bearer some-key" http://localhost:8000/jobs
```

* For valid key it let's the request through.
* For invalid key, it sends `401 - Unauthorized` response.
* For missing key, it sends `400 - Bad Request` response.
* Skips `/health` requests.

Middleware is enabled by using the `TORK_MIDDLEWARE_WEB_KEYAUTH_ENABLED=true` env var (or corresponding config property) and the `TORK_MIDDLEWARE_WEB_KEYAUTH_KEY=some-key` for the key. Tork will generate a random key and print it to the console if the key is not specified.