### PR TITLE
fix: scheduleEach: properly handle list with 1 element

### DIFF
--- a/internal/coordinator/scheduler/scheduler.go
+++ b/internal/coordinator/scheduler/scheduler.go
@@ -182,9 +182,7 @@ func (s *Scheduler) scheduleEachTask(ctx context.Context, t *tork.Task) error {
 			list = append(list, rlist.Index(i).Interface())
 		}
 	} else {
-		t.Error = err.Error()
-		t.State = tork.TaskStateFailed
-		return s.broker.PublishTask(ctx, mq.QUEUE_ERROR, t)
+		list = append(list, rlist.Interface())
 	}
 	// mark the task as running
 	if err := s.ds.UpdateTask(ctx, t.ID, func(u *tork.Task) error {


### PR DESCRIPTION
coordinator is currently crashed with this job definition input:
```yaml
---
name: sample each job
tasks:
  - name: sample each task
    each:
      list: "1"
      task:
        name: output task item
        var: eachTask{{item.index}}
        image: ubuntu:mantic
        env:
          ITEM: "{{item.value}}"
        run: echo -n $ITEM > $TORK_OUTPUT
```

```
2024-02-26 11:57:08 panic: runtime error: invalid memory address or nil pointer dereference
2024-02-26 11:57:08 [signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x65ed70]
2024-02-26 11:57:08 
2024-02-26 11:57:08 goroutine 14 [running]:
2024-02-26 11:57:08 github.com/runabol/tork/internal/coordinator/scheduler.(*Scheduler).scheduleEachTask(0x40002ea240, {0xab83a8, 0x1089820}, 0x400058c6c0)
2024-02-26 11:57:08     /go/pkg/mod/github.com/runabol/tork@v0.1.67/internal/coordinator/scheduler/scheduler.go:185 +0x2d0
2024-02-26 11:57:08 github.com/runabol/tork/internal/coordinator/scheduler.(*Scheduler).ScheduleTask(0x0?, {0xab83a8?, 0x1089820?}, 0x40005470c0?)
2024-02-26 11:57:08     /go/pkg/mod/github.com/runabol/tork@v0.1.67/internal/coordinator/scheduler/scheduler.go:30 +0x5c
2024-02-26 11:57:08 github.com/runabol/tork/internal/coordinator/handlers.(*pendingHandler).handle(0x40002ea240, {0xab83a8, 0x1089820}, {0x0?, 0x40003695c8?}, 0x400058c6c0)
2024-02-26 11:57:08     /go/pkg/mod/github.com/runabol/tork@v0.1.67/internal/coordinator/handlers/pending.go:39 +0xf0
```

I also added a test to demonstrate the issue.