### PR TITLE
Feature: skipped task state

### DIFF
--- a/internal/coordinator/handlers/completed.go
+++ b/internal/coordinator/handlers/completed.go
@@ -33,6 +33,9 @@ func NewCompletedHandler(ds datastore.Datastore, b mq.Broker, mw ...job.Middlewa
 
 func (h *completedHandler) handle(ctx context.Context, et task.EventType, t *tork.Task) error {
 	now := time.Now().UTC()
+	if t.State != tork.TaskStateCompleted && t.State != tork.TaskStateSkipped {
+		return errors.Errorf("invalid completion state: %s", t.State)
+	}
 	t.CompletedAt = &now
 	return h.completeTask(ctx, t)
 }
@@ -63,7 +66,7 @@ func (h *completedHandler) completeEachTask(ctx context.Context, t *tork.Task) e
 			if u.State != tork.TaskStateRunning && u.State != tork.TaskStateScheduled {
 				return errors.Errorf("can't complete task %s because it's %s", t.ID, u.State)
 			}
-			u.State = tork.TaskStateCompleted
+			u.State = t.State
 			u.CompletedAt = t.CompletedAt
 			u.Result = t.Result
 			return nil
@@ -117,7 +120,7 @@ func (h *completedHandler) completeParallelTask(ctx context.Context, t *tork.Tas
 			if u.State != tork.TaskStateRunning && u.State != tork.TaskStateScheduled {
 				return errors.Errorf("can't complete task %s because it's %s", t.ID, u.State)
 			}
-			u.State = tork.TaskStateCompleted
+			u.State = t.State
 			u.CompletedAt = t.CompletedAt
 			u.Result = t.Result
 			return nil
@@ -171,7 +174,7 @@ func (c *completedHandler) completeTopLevelTask(ctx context.Context, t *tork.Tas
 			if u.State != tork.TaskStateRunning && u.State != tork.TaskStateScheduled {
 				return errors.Errorf("can't complete task %s because it's %s", t.ID, u.State)
 			}
-			u.State = tork.TaskStateCompleted
+			u.State = t.State
 			u.CompletedAt = t.CompletedAt
 			u.Result = t.Result
 			return nil

--- a/internal/coordinator/handlers/completed.go
+++ b/internal/coordinator/handlers/completed.go
@@ -63,7 +63,9 @@ func (h *completedHandler) completeEachTask(ctx context.Context, t *tork.Task) e
 	err := h.ds.WithTx(ctx, func(tx datastore.Datastore) error {
 		// update actual task
 		if err := tx.UpdateTask(ctx, t.ID, func(u *tork.Task) error {
-			if u.State != tork.TaskStateRunning && u.State != tork.TaskStateScheduled {
+			if u.State != tork.TaskStateRunning &&
+				u.State != tork.TaskStateScheduled &&
+				u.State != tork.TaskStateSkipped {
 				return errors.Errorf("can't complete task %s because it's %s", t.ID, u.State)
 			}
 			u.State = t.State
@@ -117,7 +119,9 @@ func (h *completedHandler) completeParallelTask(ctx context.Context, t *tork.Tas
 	var isLast bool
 	err := h.ds.WithTx(ctx, func(tx datastore.Datastore) error {
 		if err := tx.UpdateTask(ctx, t.ID, func(u *tork.Task) error {
-			if u.State != tork.TaskStateRunning && u.State != tork.TaskStateScheduled {
+			if u.State != tork.TaskStateRunning &&
+				u.State != tork.TaskStateScheduled &&
+				u.State != tork.TaskStateSkipped {
 				return errors.Errorf("can't complete task %s because it's %s", t.ID, u.State)
 			}
 			u.State = t.State
@@ -171,7 +175,9 @@ func (c *completedHandler) completeTopLevelTask(ctx context.Context, t *tork.Tas
 	err := c.ds.WithTx(ctx, func(tx datastore.Datastore) error {
 		// update task in DB
 		if err := tx.UpdateTask(ctx, t.ID, func(u *tork.Task) error {
-			if u.State != tork.TaskStateRunning && u.State != tork.TaskStateScheduled {
+			if u.State != tork.TaskStateRunning &&
+				u.State != tork.TaskStateScheduled &&
+				u.State != tork.TaskStateSkipped {
 				return errors.Errorf("can't complete task %s because it's %s", t.ID, u.State)
 			}
 			u.State = t.State

--- a/internal/coordinator/handlers/completed_test.go
+++ b/internal/coordinator/handlers/completed_test.go
@@ -90,7 +90,7 @@ func Test_handleSkippedTask(t *testing.T) {
 
 	t1 := &tork.Task{
 		ID:          uuid.NewUUID(),
-		State:       tork.TaskStateRunning,
+		State:       tork.TaskStateSkipped,
 		StartedAt:   &now,
 		CompletedAt: &now,
 		NodeID:      uuid.NewUUID(),

--- a/internal/coordinator/handlers/pending.go
+++ b/internal/coordinator/handlers/pending.go
@@ -42,7 +42,7 @@ func (h *pendingHandler) handle(ctx context.Context, et task.EventType, t *tork.
 
 func (h *pendingHandler) skipTask(ctx context.Context, t *tork.Task) error {
 	now := time.Now().UTC()
-	t.State = tork.TaskStateScheduled
+	t.State = tork.TaskStateSkipped
 	t.ScheduledAt = &now
 	t.StartedAt = &now
 	t.CompletedAt = &now

--- a/internal/coordinator/handlers/pending_test.go
+++ b/internal/coordinator/handlers/pending_test.go
@@ -86,5 +86,5 @@ func Test_handleConditionalTask(t *testing.T) {
 
 	tk, err = ds.GetTaskByID(ctx, tk.ID)
 	assert.NoError(t, err)
-	assert.Equal(t, tork.TaskStateScheduled, tk.State)
+	assert.Equal(t, tork.TaskStateSkipped, tk.State)
 }

--- a/task.go
+++ b/task.go
@@ -19,6 +19,7 @@ const (
 	TaskStateStopped   TaskState = "STOPPED"
 	TaskStateCompleted TaskState = "COMPLETED"
 	TaskStateFailed    TaskState = "FAILED"
+	TaskStateSkipped   TaskState = "SKIPPED"
 )
 
 // Task is the basic unit of work that a Worker can handle.


### PR DESCRIPTION
When a conditional task `if` expression evaluates to `false` the task state will be set to `SKIPPED` instead of `COMPLETED`.