### PR TITLE
Allow specification of container WorkingDir in tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ go.work
 
 # local config
 config.local.toml
+
+# Binaries
+tork

--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,8 @@ CGO_ENABLED?=0
 .PHONY: all
 all: tork
 
-.PHONY: tork
-tork: 
-	CGO_ENABLED=$(CGO_ENABLED) $(SYSTEM) go build $(BUILDOPTS) -ldflags="-s -w -X github.com/runabol/tork.GitCommit=$(GITCOMMIT)" -o $(BINARY) cmd/main.go 
+tork: *.go go.* $(wildcard */**/*.go)
+	CGO_ENABLED=$(CGO_ENABLED) $(SYSTEM) go build $(BUILDOPTS) -ldflags="-s -w -X github.com/runabol/tork.GitCommit=$(GITCOMMIT)" -o $(BINARY) cmd/main.go
 
 .PHONY: clean
 clean:
@@ -21,7 +20,10 @@ clean:
 	rm -f tork
 
 .PHONY: generate-swagger
-generate-swagger: 
-	 swag init  --parseDependency -g internal/coordinator/api/api.go --output docs
-	 rm docs/docs.go
-	 rm docs/swagger.yaml
+generate-swagger: docs/swagger.json
+
+docs/swagger.json: *.go go.* $(wildcard */**/*.go)
+	# Note: this command comes from https://github.com/swaggo/swag
+	swag init  --parseDependency -g internal/coordinator/api/api.go --output docs
+	rm docs/docs.go
+	rm docs/swagger.yaml

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -186,6 +186,49 @@
                 }
             }
         },
+        "/jobs/{id}/log": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "jobs"
+                ],
+                "summary": "Get a jobs's log",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Job ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "page number",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "page size",
+                        "name": "size",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/tork.TaskLogPart"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/jobs/{id}/restart": {
             "put": {
                 "produces": [
@@ -297,6 +340,49 @@
                     }
                 }
             }
+        },
+        "/tasks/{id}/log": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "tasks"
+                ],
+                "summary": "Get a task's log",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Task ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "page number",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "page size",
+                        "name": "size",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/tork.TaskLogPart"
+                            }
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -314,24 +400,9 @@
                 "message": {}
             }
         },
-        "github_com_runabol_tork_mount.Mount": {
-            "type": "object",
-            "properties": {
-                "source": {
-                    "type": "string"
-                },
-                "target": {
-                    "type": "string"
-                },
-                "type": {
-                    "type": "string"
-                }
-            }
-        },
         "input.AuxTask": {
             "type": "object",
             "required": [
-                "image",
                 "name"
             ],
             "properties": {
@@ -402,6 +473,9 @@
                 },
                 "task": {
                     "$ref": "#/definitions/input.Task"
+                },
+                "var": {
+                    "type": "string"
                 }
             }
         },
@@ -435,6 +509,12 @@
                     "minItems": 1,
                     "items": {
                         "$ref": "#/definitions/input.Task"
+                    }
+                },
+                "webhooks": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/input.Webhook"
                     }
                 }
             }
@@ -513,6 +593,9 @@
                 "description": {
                     "type": "string"
                 },
+                "detached": {
+                    "type": "boolean"
+                },
                 "id": {
                     "type": "string"
                 },
@@ -532,6 +615,12 @@
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/input.Task"
+                    }
+                },
+                "webhooks": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/input.Webhook"
                     }
                 }
             }
@@ -571,6 +660,9 @@
                     "additionalProperties": {
                         "type": "string"
                     }
+                },
+                "gpus": {
+                    "type": "string"
                 },
                 "if": {
                     "type": "string"
@@ -626,10 +718,37 @@
                 "subjob": {
                     "$ref": "#/definitions/input.SubJob"
                 },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "timeout": {
                     "type": "string"
                 },
                 "var": {
+                    "type": "string",
+                    "maxLength": 64
+                }
+            }
+        },
+        "input.Webhook": {
+            "type": "object",
+            "required": [
+                "url"
+            ],
+            "properties": {
+                "event": {
+                    "type": "string"
+                },
+                "headers": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "url": {
                     "type": "string"
                 }
             }
@@ -665,6 +784,9 @@
                 },
                 "task": {
                     "$ref": "#/definitions/tork.Task"
+                },
+                "var": {
+                    "type": "string"
                 }
             }
         },
@@ -736,6 +858,12 @@
                     "items": {
                         "$ref": "#/definitions/tork.Task"
                     }
+                },
+                "webhooks": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/tork.Webhook"
+                    }
                 }
             }
         },
@@ -743,6 +871,12 @@
             "type": "object",
             "properties": {
                 "inputs": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "job": {
                     "type": "object",
                     "additionalProperties": {
                         "type": "string"
@@ -777,6 +911,7 @@
             "type": "string",
             "enum": [
                 "PENDING",
+                "SCHEDULED",
                 "RUNNING",
                 "CANCELLED",
                 "COMPLETED",
@@ -785,6 +920,7 @@
             ],
             "x-enum-varnames": [
                 "JobStatePending",
+                "JobStateScheduled",
                 "JobStateRunning",
                 "JobStateCancelled",
                 "JobStateCompleted",
@@ -813,10 +949,13 @@
                 "id": {
                     "type": "string"
                 },
-                "name": {
-                    "type": "string"
+                "inputs": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 },
-                "output": {
+                "name": {
                     "type": "string"
                 },
                 "parentId": {
@@ -839,6 +978,20 @@
                 }
             }
         },
+        "tork.Mount": {
+            "type": "object",
+            "properties": {
+                "source": {
+                    "type": "string"
+                },
+                "target": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
         "tork.Node": {
             "type": "object",
             "properties": {
@@ -852,6 +1005,9 @@
                     "type": "string"
                 },
                 "lastHeartbeatAt": {
+                    "type": "string"
+                },
+                "name": {
                     "type": "string"
                 },
                 "queue": {
@@ -915,6 +1071,9 @@
                 "description": {
                     "type": "string"
                 },
+                "detached": {
+                    "type": "boolean"
+                },
                 "id": {
                     "type": "string"
                 },
@@ -934,6 +1093,12 @@
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/tork.Task"
+                    }
+                },
+                "webhooks": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/tork.Webhook"
                     }
                 }
             }
@@ -983,6 +1148,9 @@
                         "type": "string"
                     }
                 },
+                "gpus": {
+                    "type": "string"
+                },
                 "id": {
                     "type": "string"
                 },
@@ -1001,7 +1169,7 @@
                 "mounts": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_runabol_tork_mount.Mount"
+                        "$ref": "#/definitions/tork.Mount"
                     }
                 },
                 "name": {
@@ -1064,10 +1232,19 @@
                 "subjob": {
                     "$ref": "#/definitions/tork.SubJobTask"
                 },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "timeout": {
                     "type": "string"
                 },
                 "var": {
+                    "type": "string"
+                },
+                "workingDir": {
                     "type": "string"
                 }
             }
@@ -1079,6 +1256,23 @@
                     "type": "string"
                 },
                 "memory": {
+                    "type": "string"
+                }
+            }
+        },
+        "tork.TaskLogPart": {
+            "type": "object",
+            "properties": {
+                "contents": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "number": {
+                    "type": "integer"
+                },
+                "taskId": {
                     "type": "string"
                 }
             }
@@ -1103,7 +1297,8 @@
                 "CANCELLED",
                 "STOPPED",
                 "COMPLETED",
-                "FAILED"
+                "FAILED",
+                "SKIPPED"
             ],
             "x-enum-varnames": [
                 "TaskStatePending",
@@ -1112,8 +1307,26 @@
                 "TaskStateCancelled",
                 "TaskStateStopped",
                 "TaskStateCompleted",
-                "TaskStateFailed"
+                "TaskStateFailed",
+                "TaskStateSkipped"
             ]
+        },
+        "tork.Webhook": {
+            "type": "object",
+            "properties": {
+                "event": {
+                    "type": "string"
+                },
+                "headers": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "url": {
+                    "type": "string"
+                }
+            }
         }
     }
 }

--- a/input/task.go
+++ b/input/task.go
@@ -30,7 +30,7 @@ type Task struct {
 	SubJob      *SubJob           `json:"subjob,omitempty" yaml:"subjob,omitempty"`
 	GPUs        string            `json:"gpus,omitempty" yaml:"gpus,omitempty"`
 	Tags        []string          `json:"tags,omitempty" yaml:"tags,omitempty"`
-	WorkDir     string            `json:"workDir,omitempty" yaml:"workingDir,omitempty"`
+	WorkDir     string            `json:"workDir,omitempty" yaml:"workDir,omitempty"`
 }
 
 type SubJob struct {

--- a/input/task.go
+++ b/input/task.go
@@ -30,6 +30,7 @@ type Task struct {
 	SubJob      *SubJob           `json:"subjob,omitempty" yaml:"subjob,omitempty"`
 	GPUs        string            `json:"gpus,omitempty" yaml:"gpus,omitempty"`
 	Tags        []string          `json:"tags,omitempty" yaml:"tags,omitempty"`
+	WorkDir     string            `json:"workDir,omitempty" yaml:"workingDir,omitempty"`
 }
 
 type SubJob struct {
@@ -187,6 +188,7 @@ func (i Task) toTask() *tork.Task {
 		SubJob:      subjob,
 		GPUs:        i.GPUs,
 		Tags:        i.Tags,
+		WorkDir:     i.WorkDir,
 	}
 }
 

--- a/runtime/docker/archive.go
+++ b/runtime/docker/archive.go
@@ -1,0 +1,70 @@
+package docker
+
+import (
+	"archive/tar"
+	"bufio"
+	"context"
+	"errors"
+	"os"
+
+	"github.com/docker/docker/api/types"
+)
+
+type archiveFile struct {
+	name     string
+	mode     int64
+	contents []byte
+}
+
+func createArchive(afs []archiveFile) (archive *os.File, err error) {
+	archive, err = os.CreateTemp("", "archive-*.tar")
+	if err != nil {
+		return
+	}
+
+	defer func() {
+		if err != nil {
+			err = errors.Join(err, archive.Close())
+		}
+	}()
+
+	buf := bufio.NewWriter(archive)
+	tw := tar.NewWriter(buf)
+
+	for _, af := range afs {
+		err = tw.WriteHeader(&tar.Header{
+			Name: af.name,
+			Mode: af.mode,
+			Size: int64(len(af.contents)),
+		})
+		if err != nil {
+			return
+		}
+
+		_, err = tw.Write(af.contents)
+		if err != nil {
+			return
+		}
+	}
+
+	err = buf.Flush()
+	if err != nil {
+		return
+	}
+
+	return archive, tw.Close()
+}
+
+func (d *DockerRuntime) copyArchive(ctx context.Context, archive *os.File, containerID, destination string) (err error) {
+	defer func() {
+		for _, e := range []error{
+			archive.Close(),
+			os.Remove(archive.Name()),
+		} {
+			err = errors.Join(err, e)
+		}
+	}()
+
+	r := bufio.NewReader(archive)
+	return d.client.CopyToContainer(ctx, containerID, destination, r, types.CopyToContainerOptions{})
+}

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -266,8 +266,12 @@ func (d *DockerRuntime) doRun(ctx context.Context, t *tork.Task, logger io.Write
 	}
 	// we want to override the default
 	// image WORKDIR only if the task
-	// introduces work files
-	if len(t.Files) > 0 {
+	// introduces work files _or_ if the
+	// user specifies a WORKDIR
+	switch {
+	case t.WorkingDir != "":
+		cc.WorkingDir = t.WorkingDir
+	case len(t.Files) > 0:
 		cc.WorkingDir = workdir.Target
 	}
 

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -445,7 +445,7 @@ func (d *DockerRuntime) initWorkDir(ctx context.Context, containerID string, t *
 	return d.copyArchive(ctx, archive, containerID, t.Workdir())
 }
 
-func createTorkArchive(t *tork.Task) (*os.File, error) {
+func createTorkArchive(t *tork.Task) (string, error) {
 	afs := []archiveFile{
 		{
 			name:     "stdout",
@@ -465,7 +465,7 @@ func createTorkArchive(t *tork.Task) (*os.File, error) {
 	return createArchive(afs)
 }
 
-func createWorkDirArchive(t *tork.Task) (*os.File, error) {
+func createWorkDirArchive(t *tork.Task) (string, error) {
 	afs := make([]archiveFile, 0)
 
 	for filename, contents := range t.Files {

--- a/runtime/docker/docker_test.go
+++ b/runtime/docker/docker_test.go
@@ -342,7 +342,7 @@ func TestRunTaskWithVolumeAndWorkdir(t *testing.T) {
 				Target: "/xyz",
 			},
 		},
-		WorkingDir: "/xyz",
+		WorkDir: "/xyz",
 	}
 	err = rt.Run(ctx, t1)
 	assert.NoError(t, err)
@@ -364,7 +364,7 @@ func TestRunTaskWithTempfsAndWorkdir(t *testing.T) {
 				Target: "/xyz",
 			},
 		},
-		WorkingDir: "/xyz",
+		WorkDir: "/xyz",
 	}
 	err = rt.Run(ctx, t1)
 	assert.NoError(t, err)

--- a/task.go
+++ b/task.go
@@ -22,6 +22,12 @@ const (
 	TaskStateSkipped   TaskState = "SKIPPED"
 )
 
+var (
+	// DefaultWorkDir is the directory where `Task.File`s are
+	// written by default, should `Task.WorkDir` not be set
+	DefaultWorkDir = "/tork/workdir"
+)
+
 // Task is the basic unit of work that a Worker can handle.
 type Task struct {
 	ID          string            `json:"id,omitempty"`
@@ -61,7 +67,7 @@ type Task struct {
 	SubJob      *SubJobTask       `json:"subjob,omitempty"`
 	GPUs        string            `json:"gpus,omitempty"`
 	Tags        []string          `json:"tags,omitempty"`
-	WorkingDir  string            `json:"workingDir,omitempty"`
+	WorkDir     string            `json:"workDir,omitempty"`
 }
 
 type TaskSummary struct {
@@ -196,8 +202,19 @@ func (t *Task) Clone() *Task {
 		SubJob:      subjob,
 		GPUs:        t.GPUs,
 		Tags:        t.Tags,
-		WorkingDir:  t.WorkingDir,
+		WorkDir:     t.WorkDir,
 	}
+}
+
+// Workdir will return the correct value to set a container's
+// working directory to when necessary, such as when a task
+// specifically requests it, or when a task contains files
+func (t *Task) Workdir() string {
+	if t.WorkDir != "" {
+		return t.WorkDir
+	}
+
+	return DefaultWorkDir
 }
 
 func CloneTasks(tasks []*Task) []*Task {

--- a/task.go
+++ b/task.go
@@ -61,6 +61,7 @@ type Task struct {
 	SubJob      *SubJobTask       `json:"subjob,omitempty"`
 	GPUs        string            `json:"gpus,omitempty"`
 	Tags        []string          `json:"tags,omitempty"`
+	WorkingDir  string            `json:"workingDir,omitempty"`
 }
 
 type TaskSummary struct {

--- a/task.go
+++ b/task.go
@@ -196,6 +196,7 @@ func (t *Task) Clone() *Task {
 		SubJob:      subjob,
 		GPUs:        t.GPUs,
 		Tags:        t.Tags,
+		WorkingDir:  t.WorkingDir,
 	}
 }
 


### PR DESCRIPTION
Allow for the setting of workingdirs at the task level

This closes https://github.com/runabol/tork/issues/361, and allows for tasks to set the correct workingdir for a container (it is currently ignored for shell runtimes)- this helps avoid things like `cd /foo` in commands; it also has the side effect of creating directories under certain circumstances.

Additionally, this PR contains an updated swagger.json to include the new task field; this command doesn't seem to have been run for a couple of changes and so it has pulled in some other changes.

Happy to remove that change and open a new PR if needed.

**Edit to add:** I haven't updated `input.Task` to include a working dir because I want to wait and see whether I should make that available in yaml; I also don't know where the docs live so I can document public interfaces like the yaml file