### PR TITLE
Log shipping improvements

### DIFF
--- a/internal/logging/forwarder.go
+++ b/internal/logging/forwarder.go
@@ -2,7 +2,10 @@ package logging
 
 import (
 	"context"
+	"fmt"
+	"time"
 
+	"github.com/rs/zerolog/log"
 	"github.com/runabol/tork"
 	"github.com/runabol/tork/mq"
 )
@@ -11,16 +14,49 @@ type Forwarder struct {
 	Broker mq.Broker
 	TaskID string
 	part   int
+	q      chan []byte
+}
+
+func NewForwarder(broker mq.Broker, taskID string) *Forwarder {
+	f := &Forwarder{
+		Broker: broker,
+		TaskID: taskID,
+		q:      make(chan []byte, 1000),
+	}
+	go f.startFlushTimer()
+	return f
 }
 
 func (r *Forwarder) Write(p []byte) (int, error) {
-	r.part = r.part + 1
-	if err := r.Broker.PublishTaskLogPart(context.Background(), &tork.TaskLogPart{
-		Number:   r.part,
-		TaskID:   r.TaskID,
-		Contents: string(p),
-	}); err != nil {
-		return 0, err
+	pc := make([]byte, len(p))
+	copy(pc, p)
+	select {
+	case r.q <- pc:
+		return len(p), nil
+	default:
+		return 0, fmt.Errorf("buffer full, unable to write")
 	}
-	return len(p), nil
+}
+
+func (r *Forwarder) startFlushTimer() {
+	ticker := time.NewTicker(time.Second)
+	buffer := make([]byte, 0)
+	for {
+		select {
+		case p := <-r.q:
+			buffer = append(buffer, p...)
+		case <-ticker.C:
+			if len(buffer) > 0 {
+				r.part = r.part + 1
+				if err := r.Broker.PublishTaskLogPart(context.Background(), &tork.TaskLogPart{
+					Number:   r.part,
+					TaskID:   r.TaskID,
+					Contents: string(buffer),
+				}); err != nil {
+					log.Error().Err(err).Msgf("error forwarding task log part")
+				}
+				buffer = buffer[:0] // clear buffer
+			}
+		}
+	}
 }

--- a/internal/logging/forwarder_test.go
+++ b/internal/logging/forwarder_test.go
@@ -1,29 +1,51 @@
 package logging
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/runabol/tork"
 	"github.com/runabol/tork/mq"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestForward(t *testing.T) {
+func TestForwardTimeout(t *testing.T) {
 	b := mq.NewInMemoryBroker()
 
 	processed := make(chan any)
 	err := b.SubscribeForTaskLogPart(func(p *tork.TaskLogPart) {
+		assert.Equal(t, "hello\n", p.Contents)
+		processed <- 1
+	})
+	assert.NoError(t, err)
+
+	fwd := NewForwarder(b, "some-task-id")
+	for i := 0; i < 1; i++ {
+		_, err = fwd.Write([]byte("hello\n"))
+		assert.NoError(t, err)
+		<-time.After(time.Millisecond * 1100)
+	}
+
+	<-processed
+}
+
+func TestForwardBatch(t *testing.T) {
+	b := mq.NewInMemoryBroker()
+
+	processed := make(chan any)
+	err := b.SubscribeForTaskLogPart(func(p *tork.TaskLogPart) {
+		assert.Equal(t, "hello 0\nhello 1\nhello 2\nhello 3\nhello 4\n", p.Contents)
 		close(processed)
 	})
 	assert.NoError(t, err)
 
-	fwd := &Forwarder{
-		Broker: b,
-		TaskID: "some-task-id",
-	}
+	fwd := NewForwarder(b, "some-task-id")
 
-	_, err = fwd.Write([]byte("log line"))
-	assert.NoError(t, err)
+	for i := 0; i < 5; i++ {
+		_, err = fwd.Write([]byte(fmt.Sprintf("hello %d\n", i)))
+		assert.NoError(t, err)
+	}
 
 	<-processed
 }

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -127,10 +127,7 @@ func (d *DockerRuntime) Run(ctx context.Context, t *tork.Task) error {
 	}
 	var logger io.Writer
 	if d.broker != nil {
-		logger = &logging.Forwarder{
-			Broker: d.broker,
-			TaskID: t.ID,
-		}
+		logger = logging.NewForwarder(d.broker, t.ID)
 	} else {
 		logger = os.Stdout
 	}

--- a/runtime/shell/shell.go
+++ b/runtime/shell/shell.go
@@ -99,10 +99,7 @@ func (r *ShellRuntime) Run(ctx context.Context, t *tork.Task) error {
 	}
 	var logger io.Writer
 	if r.broker != nil {
-		logger = &logging.Forwarder{
-			Broker: r.broker,
-			TaskID: t.ID,
-		}
+		logger = logging.NewForwarder(r.broker, t.ID)
 	} else {
 		logger = os.Stdout
 	}

--- a/version.go
+++ b/version.go
@@ -1,7 +1,7 @@
 package tork
 
 const (
-	Version = "0.1.71"
+	Version = "0.1.72"
 )
 
 var (


### PR DESCRIPTION
This PR improves log shipping by buffering source log messages for upto one second before forwarding them to the Coordinator. The intention is to reduce the amount of messages being generated by the worker as well as reduce the number of log parts in the database.