### PR TITLE
Feature: task priority (RabbitMQ)

### DIFF
--- a/datastore/postgres/postgres.go
+++ b/datastore/postgres/postgres.go
@@ -240,12 +240,13 @@ func (ds *PostgresDatastore) CreateTask(ctx context.Context, t *tork.Task) error
 			registry, -- $34
 			gpus, -- $35
 			if_, -- $36
-			tags -- $37
+			tags, -- $37
+			priority -- $38
 		  ) 
 	      values (
 			$1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,
 		    $15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,
-			$27,$28,$29,$30,$31,$32,$33,$34,$35,$36,$37)`
+			$27,$28,$29,$30,$31,$32,$33,$34,$35,$36,$37,$38)`
 	_, err = ds.exec(q,
 		t.ID,                         // $1
 		t.JobID,                      // $2
@@ -284,6 +285,7 @@ func (ds *PostgresDatastore) CreateTask(ctx context.Context, t *tork.Task) error
 		t.GPUs,                       // $35
 		t.If,                         // $36
 		pq.StringArray(t.Tags),       // $37
+		t.Priority,                   // $38
 	)
 	if err != nil {
 		return errors.Wrapf(err, "error inserting task to the db")

--- a/datastore/postgres/record.go
+++ b/datastore/postgres/record.go
@@ -48,6 +48,7 @@ type taskRecord struct {
 	GPUs        string         `db:"gpus"`
 	IF          string         `db:"if_"`
 	Tags        pq.StringArray `db:"tags"`
+	Priority    int            `db:"priority"`
 }
 
 type jobRecord struct {
@@ -204,6 +205,7 @@ func (r taskRecord) toTask() (*tork.Task, error) {
 		GPUs:        r.GPUs,
 		If:          r.IF,
 		Tags:        r.Tags,
+		Priority:    r.Priority,
 	}, nil
 }
 

--- a/db/postgres/schema.go
+++ b/db/postgres/schema.go
@@ -73,7 +73,7 @@ CREATE TABLE tasks (
     error_        text,
     pre_tasks     jsonb,
     post_tasks    jsonb,
-    mounts       jsonb,
+    mounts        jsonb,
     node_id       varchar(32),
     retry         jsonb,
     limits        jsonb,
@@ -88,7 +88,8 @@ CREATE TABLE tasks (
     networks      text[],
     gpus          text,
     if_           text,
-    tags          text[]
+    tags          text[],
+    priority      int
 );
 
 CREATE INDEX idx_tasks_state ON tasks (state);

--- a/input/job.go
+++ b/input/job.go
@@ -20,10 +20,11 @@ type Job struct {
 }
 
 type Defaults struct {
-	Retry   *Retry  `json:"retry,omitempty" yaml:"retry,omitempty"`
-	Limits  *Limits `json:"limits,omitempty" yaml:"limits,omitempty"`
-	Timeout string  `json:"timeout,omitempty" yaml:"timeout,omitempty" validate:"duration"`
-	Queue   string  `json:"queue,omitempty" yaml:"queue,omitempty" validate:"queue"`
+	Retry    *Retry  `json:"retry,omitempty" yaml:"retry,omitempty"`
+	Limits   *Limits `json:"limits,omitempty" yaml:"limits,omitempty"`
+	Timeout  string  `json:"timeout,omitempty" yaml:"timeout,omitempty" validate:"duration"`
+	Queue    string  `json:"queue,omitempty" yaml:"queue,omitempty" validate:"queue"`
+	Priority int     `json:"priority,omitempty" yaml:"priority,omitempty" validate:"min=0,max=9"`
 }
 
 type Webhook struct {
@@ -82,6 +83,7 @@ func (d Defaults) ToJobDefaults() *tork.JobDefaults {
 	}
 	jd.Timeout = d.Timeout
 	jd.Queue = d.Queue
+	jd.Priority = d.Priority
 	return &jd
 }
 

--- a/input/task.go
+++ b/input/task.go
@@ -31,6 +31,7 @@ type Task struct {
 	GPUs        string            `json:"gpus,omitempty" yaml:"gpus,omitempty"`
 	Tags        []string          `json:"tags,omitempty" yaml:"tags,omitempty"`
 	Workdir     string            `json:"workdir,omitempty" yaml:"workdir,omitempty"`
+	Priority    int               `json:"priority,omitempty" yaml:"priority,omitempty" validate:"min=0,max=9"`
 }
 
 type SubJob struct {
@@ -189,6 +190,7 @@ func (i Task) toTask() *tork.Task {
 		GPUs:        i.GPUs,
 		Tags:        i.Tags,
 		Workdir:     i.Workdir,
+		Priority:    i.Priority,
 	}
 }
 

--- a/internal/coordinator/scheduler/scheduler.go
+++ b/internal/coordinator/scheduler/scheduler.go
@@ -67,6 +67,9 @@ func (s *Scheduler) scheduleRegularTask(ctx context.Context, t *tork.Task) error
 				t.Retry.Limit = job.Defaults.Retry.Limit
 			}
 		}
+		if t.Priority == 0 {
+			t.Priority = job.Defaults.Priority
+		}
 	}
 	if t.Queue == "" {
 		t.Queue = mq.QUEUE_DEFAULT
@@ -81,6 +84,7 @@ func (s *Scheduler) scheduleRegularTask(ctx context.Context, t *tork.Task) error
 		u.Limits = t.Limits
 		u.Timeout = t.Timeout
 		u.Retry = t.Retry
+		u.Priority = t.Priority
 		return nil
 	}); err != nil {
 		return errors.Wrapf(err, "error updating task in datastore")

--- a/internal/coordinator/scheduler/scheduler_test.go
+++ b/internal/coordinator/scheduler/scheduler_test.go
@@ -120,7 +120,8 @@ func Test_scheduleRegularTaskJobDefaults(t *testing.T) {
 				CPUs:   ".5",
 				Memory: "10m",
 			},
-			Timeout: "5s",
+			Timeout:  "5s",
+			Priority: 3,
 		},
 	}
 
@@ -146,6 +147,7 @@ func Test_scheduleRegularTaskJobDefaults(t *testing.T) {
 	assert.Equal(t, ".5", tk.Limits.CPUs)
 	assert.Equal(t, "10m", tk.Limits.Memory)
 	assert.Equal(t, "5s", tk.Timeout)
+	assert.Equal(t, 3, tk.Priority)
 }
 
 func Test_scheduleParallelTask(t *testing.T) {

--- a/job.go
+++ b/job.go
@@ -65,10 +65,11 @@ type JobContext struct {
 }
 
 type JobDefaults struct {
-	Retry   *TaskRetry  `json:"retry,omitempty"`
-	Limits  *TaskLimits `json:"limits,omitempty"`
-	Timeout string      `json:"timeout,omitempty"`
-	Queue   string      `json:"queue,omitempty"`
+	Retry    *TaskRetry  `json:"retry,omitempty"`
+	Limits   *TaskLimits `json:"limits,omitempty"`
+	Timeout  string      `json:"timeout,omitempty"`
+	Queue    string      `json:"queue,omitempty"`
+	Priority int         `json:"priority,omitempty"`
 }
 
 type Webhook struct {
@@ -132,6 +133,7 @@ func (d *JobDefaults) Clone() *JobDefaults {
 	}
 	clone.Queue = d.Queue
 	clone.Timeout = d.Timeout
+	clone.Priority = d.Priority
 	return &clone
 }
 

--- a/mq/queues.go
+++ b/mq/queues.go
@@ -1,6 +1,10 @@
 package mq
 
-import "golang.org/x/exp/slices"
+import (
+	"strings"
+
+	"golang.org/x/exp/slices"
+)
 
 const (
 	// The queue used by the API to insert new tasks into
@@ -52,4 +56,8 @@ func IsCoordinatorQueue(qname string) bool {
 
 func IsWorkerQueue(qname string) bool {
 	return !IsCoordinatorQueue(qname)
+}
+
+func IsTaskQueue(qname string) bool {
+	return !IsCoordinatorQueue(qname) && !strings.HasPrefix(qname, QUEUE_EXCLUSIVE_PREFIX)
 }

--- a/task.go
+++ b/task.go
@@ -62,6 +62,7 @@ type Task struct {
 	GPUs        string            `json:"gpus,omitempty"`
 	Tags        []string          `json:"tags,omitempty"`
 	Workdir     string            `json:"workdir,omitempty"`
+	Priority    int               `json:"priority,omitempty"`
 }
 
 type TaskSummary struct {
@@ -197,6 +198,7 @@ func (t *Task) Clone() *Task {
 		GPUs:        t.GPUs,
 		Tags:        t.Tags,
 		Workdir:     t.Workdir,
+		Priority:    t.Priority,
 	}
 }
 


### PR DESCRIPTION
Adds support for task priority when using RabbitMQ as a broker. 

This features builds on RabbitMQ support for priority queues: https://www.rabbitmq.com/docs/priority

This change does require re-creating the task queues (by simply deleting them and letting Tork re-create them).

There is also a DB schema change adding the priority field to the `tasks` table:

```
alter table tasks add priority int default 0
```
To use priority in your jobs set the `priority` property on the task (values 1-9). Higher values indicate higher priority. Example:

```yaml
- name: my first task
  image: alpine:3.18.3
  run: sleep 3
  priority: 1
```

This task will execute as a priority over tasks with no `priority` defined.

You can also set the default priority for a task at the job level:


```yaml
name: my job
defaults:
  priority: 1
tasks:
- name: my first task
  image: alpine:3.18.3
  run: sleep 3
```

Workers that are already processing a task -- even a lower priority task -- will complete the task before considering any prioritized tasks.