### PR TITLE
Feature: user authentication

### DIFF
--- a/configs/sample.config.toml
+++ b/configs/sample.config.toml
@@ -35,6 +35,7 @@ endpoints.tasks = true   # turn on|off the /tasks endpoints
 endpoints.nodes = true   # turn on|off the /nodes endpoint
 endpoints.queues = true  # turn on|off the /queues endpoint
 endpoints.metrics = true # turn on|off the /metrics endpoint
+endpoints.users = true   # turn on|off the /users endpoints
 
 [coordinator.queues]
 completed = 1 # completed queue consumers
@@ -55,8 +56,6 @@ headers = "*"
 # basic auth middleware
 [middleware.web.basicauth]
 enabled = false
-username = "tork"
-password = ""     # if left blank, it will auto-generate a password and print it to the logs on startup
 
 [middleware.web.keyauth]
 enabled = false

--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -13,6 +13,7 @@ var (
 	ErrTaskNotFound    = errors.New("task not found")
 	ErrNodeNotFound    = errors.New("node not found")
 	ErrJobNotFound     = errors.New("job not found")
+	ErrUserNotFound    = errors.New("user not found")
 	ErrContextNotFound = errors.New("context not found")
 )
 
@@ -39,6 +40,9 @@ type Datastore interface {
 	GetJobByID(ctx context.Context, id string) (*tork.Job, error)
 	GetJobLogParts(ctx context.Context, jobID string, page, size int) (*Page[*tork.TaskLogPart], error)
 	GetJobs(ctx context.Context, q string, page, size int) (*Page[*tork.JobSummary], error)
+
+	CreateUser(ctx context.Context, u *tork.User) error
+	GetUser(ctx context.Context, username string) (*tork.User, error)
 
 	GetMetrics(ctx context.Context) (*tork.Metrics, error)
 

--- a/datastore/inmemory/inmemory_test.go
+++ b/datastore/inmemory/inmemory_test.go
@@ -29,6 +29,31 @@ func TestInMemoryCreateAndGetTask(t *testing.T) {
 	assert.Equal(t, t1.ID, t2.ID)
 }
 
+func TestInMemoryCreateJob(t *testing.T) {
+	ctx := context.Background()
+	ds := inmemory.NewInMemoryDatastore()
+	now := time.Now().UTC()
+	u := &tork.User{
+		ID:        uuid.NewUUID(),
+		Username:  uuid.NewShortUUID(),
+		Name:      "Tester",
+		CreatedAt: &now,
+	}
+	err := ds.CreateUser(ctx, u)
+	assert.NoError(t, err)
+	j1 := tork.Job{
+		ID:        uuid.NewUUID(),
+		CreatedBy: u,
+	}
+	err = ds.CreateJob(ctx, &j1)
+	assert.NoError(t, err)
+	assert.Equal(t, u.Username, j1.CreatedBy.Username)
+
+	j2, err := ds.GetJobByID(ctx, j1.ID)
+	assert.NoError(t, err)
+	assert.Equal(t, u.Username, j2.CreatedBy.Username)
+}
+
 func TestInMemoryGetActiveTasks(t *testing.T) {
 	ctx := context.Background()
 	ds := inmemory.NewInMemoryDatastore()

--- a/datastore/postgres/postgres_test.go
+++ b/datastore/postgres/postgres_test.go
@@ -28,6 +28,12 @@ func TestPostgresCreateAndGetTask(t *testing.T) {
 	}
 	err = ds.CreateJob(ctx, &j1)
 	assert.NoError(t, err)
+	assert.Equal(t, tork.USER_GUEST, j1.CreatedBy.Username)
+
+	j2, err := ds.GetJobByID(ctx, j1.ID)
+	assert.NoError(t, err)
+	assert.Equal(t, tork.USER_GUEST, j2.CreatedBy.Username)
+
 	t1 := tork.Task{
 		ID:          uuid.NewUUID(),
 		CreatedAt:   &now,
@@ -58,6 +64,33 @@ func TestPostgresCreateAndGetTask(t *testing.T) {
 	assert.Equal(t, []string([]string{"tag1", "tag2"}), t2.Tags)
 	assert.Equal(t, "/some/dir", t2.Workdir)
 	assert.Equal(t, 2, t2.Priority)
+}
+
+func TestPostgresCreateJob(t *testing.T) {
+	ctx := context.Background()
+	dsn := "host=localhost user=tork password=tork dbname=tork port=5432 sslmode=disable"
+	ds, err := NewPostgresDataStore(dsn)
+	assert.NoError(t, err)
+	now := time.Now().UTC()
+	u := &tork.User{
+		ID:        uuid.NewUUID(),
+		Username:  uuid.NewShortUUID(),
+		Name:      "Tester",
+		CreatedAt: &now,
+	}
+	err = ds.CreateUser(ctx, u)
+	assert.NoError(t, err)
+	j1 := tork.Job{
+		ID:        uuid.NewUUID(),
+		CreatedBy: u,
+	}
+	err = ds.CreateJob(ctx, &j1)
+	assert.NoError(t, err)
+	assert.Equal(t, u.Username, j1.CreatedBy.Username)
+
+	j2, err := ds.GetJobByID(ctx, j1.ID)
+	assert.NoError(t, err)
+	assert.Equal(t, u.Username, j2.CreatedBy.Username)
 }
 
 func TestPostgresCreateAndGetParallelTask(t *testing.T) {

--- a/db/postgres/schema.go
+++ b/db/postgres/schema.go
@@ -16,11 +16,23 @@ CREATE TABLE nodes (
 
 CREATE INDEX idx_nodes_heartbeat ON nodes (last_heartbeat_at);
 
+CREATE TABLE users (
+    id          varchar(32)  not null primary key,
+    name        varchar(64)  not null,
+    username_   varchar(64)  not null unique,
+    password_   varchar(256) not null,
+    created_at  timestamp    not null,
+    is_disabled boolean      not null default false
+);
+
+insert into users (SELECT REPLACE(gen_random_uuid()::text, '-', ''),'Guest','guest','',current_timestamp,true);
+
 CREATE TABLE jobs (
     id            varchar(32) not null primary key,
     name          varchar(256),
     state         varchar(10) not null,
     created_at    timestamp   not null,
+	created_by    varchar(32) not null references users(id),
     started_at    timestamp,
     completed_at  timestamp,
     failed_at     timestamp,

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/shirou/gopsutil/v3 v3.24.3
 	github.com/stretchr/testify v1.9.0
 	github.com/urfave/cli/v2 v2.27.2
+	golang.org/x/crypto v0.22.0
 	golang.org/x/exp v0.0.0-20230807204917-050eac23e9de
 	golang.org/x/sys v0.19.0
 	golang.org/x/time v0.5.0
@@ -83,7 +84,6 @@ require (
 	go.opentelemetry.io/otel/metric v1.26.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.26.0 // indirect
 	go.opentelemetry.io/otel/trace v1.26.0 // indirect
-	golang.org/x/crypto v0.22.0 // indirect
 	golang.org/x/mod v0.11.0 // indirect
 	golang.org/x/net v0.24.0 // indirect
 	golang.org/x/text v0.14.0 // indirect

--- a/internal/coordinator/scheduler/scheduler.go
+++ b/internal/coordinator/scheduler/scheduler.go
@@ -100,10 +100,15 @@ func (s *Scheduler) scheduleSubJob(ctx context.Context, t *tork.Task) error {
 }
 
 func (s *Scheduler) scheduleAttachedSubJob(ctx context.Context, t *tork.Task) error {
+	job, err := s.ds.GetJobByID(ctx, t.JobID)
+	if err != nil {
+		return err
+	}
 	now := time.Now().UTC()
 	subjob := &tork.Job{
 		ID:          uuid.NewUUID(),
 		CreatedAt:   now,
+		CreatedBy:   job.CreatedBy,
 		ParentID:    t.ID,
 		Name:        t.SubJob.Name,
 		Description: t.SubJob.Description,
@@ -131,9 +136,14 @@ func (s *Scheduler) scheduleAttachedSubJob(ctx context.Context, t *tork.Task) er
 }
 
 func (s *Scheduler) scheduleDetachedSubJob(ctx context.Context, t *tork.Task) error {
+	job, err := s.ds.GetJobByID(ctx, t.JobID)
+	if err != nil {
+		return err
+	}
 	now := time.Now().UTC()
 	subjob := &tork.Job{
 		ID:          uuid.NewUUID(),
+		CreatedBy:   job.CreatedBy,
 		CreatedAt:   now,
 		Name:        t.SubJob.Name,
 		Description: t.SubJob.Description,

--- a/internal/hash/hash.go
+++ b/internal/hash/hash.go
@@ -1,0 +1,15 @@
+package hash
+
+import (
+	"golang.org/x/crypto/bcrypt"
+)
+
+func Password(password string) (string, error) {
+	bytes, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	return string(bytes), err
+}
+
+func CheckPasswordHash(password, hash string) bool {
+	err := bcrypt.CompareHashAndPassword([]byte(hash), []byte(password))
+	return err == nil
+}

--- a/internal/hash/hash_test.go
+++ b/internal/hash/hash_test.go
@@ -1,0 +1,15 @@
+package hash_test
+
+import (
+	"testing"
+
+	"github.com/runabol/tork/internal/hash"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHashPassword(t *testing.T) {
+	hashed, err := hash.Password("1234")
+	assert.NoError(t, err)
+	match := hash.CheckPasswordHash("1234", hashed)
+	assert.True(t, match)
+}

--- a/job.go
+++ b/job.go
@@ -25,6 +25,7 @@ type Job struct {
 	Description string            `json:"description,omitempty"`
 	State       JobState          `json:"state,omitempty"`
 	CreatedAt   time.Time         `json:"createdAt,omitempty"`
+	CreatedBy   *User             `json:"createdBy,omitempty"`
 	StartedAt   *time.Time        `json:"startedAt,omitempty"`
 	CompletedAt *time.Time        `json:"completedAt,omitempty"`
 	FailedAt    *time.Time        `json:"failedAt,omitempty"`
@@ -43,6 +44,7 @@ type Job struct {
 
 type JobSummary struct {
 	ID          string            `json:"id,omitempty"`
+	CreatedBy   *User             `json:"createdBy,omitempty"`
 	ParentID    string            `json:"parentId,omitempty"`
 	Inputs      map[string]string `json:"inputs,omitempty"`
 	Name        string            `json:"name,omitempty"`
@@ -83,12 +85,17 @@ func (j *Job) Clone() *Job {
 	if j.Defaults != nil {
 		defaults = j.Defaults.Clone()
 	}
+	var createdBy *User
+	if j.CreatedBy != nil {
+		createdBy = j.CreatedBy.Clone()
+	}
 	return &Job{
 		ID:          j.ID,
 		Name:        j.Name,
 		Description: j.Description,
 		State:       j.State,
 		CreatedAt:   j.CreatedAt,
+		CreatedBy:   createdBy,
 		StartedAt:   j.StartedAt,
 		CompletedAt: j.CompletedAt,
 		FailedAt:    j.FailedAt,
@@ -140,6 +147,7 @@ func (d *JobDefaults) Clone() *JobDefaults {
 func NewJobSummary(j *Job) *JobSummary {
 	return &JobSummary{
 		ID:          j.ID,
+		CreatedBy:   j.CreatedBy,
 		ParentID:    j.ParentID,
 		Name:        j.Name,
 		Description: j.Description,

--- a/user.go
+++ b/user.go
@@ -1,0 +1,31 @@
+package tork
+
+import "time"
+
+type UsernameKey string
+
+const (
+	USER_GUEST string      = "guest"
+	USERNAME   UsernameKey = "username"
+)
+
+type User struct {
+	ID           string     `json:"id,omitempty"`
+	Name         string     `json:"name,omitempty"`
+	Username     string     `json:"username,omitempty"`
+	PasswordHash string     `json:"-"`
+	Password     string     `json:"password,omitempty"`
+	CreatedAt    *time.Time `json:"createdAt,omitempty"`
+	Disabled     bool       `json:"disabled,omitempty"`
+}
+
+func (u *User) Clone() *User {
+	return &User{
+		ID:           u.ID,
+		Name:         u.Name,
+		Username:     u.Username,
+		PasswordHash: u.PasswordHash,
+		CreatedAt:    u.CreatedAt,
+		Disabled:     u.Disabled,
+	}
+}


### PR DESCRIPTION
This PR adds support for user creation and user assignment when a job is created.

1. New `users` table to store username and passwords (hashed).
2. A new built-in `guest` user that can be assigned to jobs when login is not enforced.
3. New endpoint to create users: `POST /users`.
4. `createdBy` field added to each job.

To turn on login using basic auth use `middleware.web.basicauth=true` or `TORK_MIDDLEWARE_WEB_BASICAUTH_ENABLED=true`