### PR TITLE
Feature: job tags

### DIFF
--- a/datastore/postgres/record.go
+++ b/datastore/postgres/record.go
@@ -53,27 +53,28 @@ type taskRecord struct {
 }
 
 type jobRecord struct {
-	ID          string     `db:"id"`
-	Name        string     `db:"name"`
-	Description string     `db:"description"`
-	State       string     `db:"state"`
-	CreatedAt   time.Time  `db:"created_at"`
-	CreatedBy   string     `db:"created_by"`
-	StartedAt   *time.Time `db:"started_at"`
-	CompletedAt *time.Time `db:"completed_at"`
-	FailedAt    *time.Time `db:"failed_at"`
-	Tasks       []byte     `db:"tasks"`
-	Position    int        `db:"position"`
-	Inputs      []byte     `db:"inputs"`
-	Context     []byte     `db:"context"`
-	ParentID    string     `db:"parent_id"`
-	TaskCount   int        `db:"task_count"`
-	Output      string     `db:"output_"`
-	Result      string     `db:"result"`
-	Error       string     `db:"error_"`
-	TS          string     `db:"ts"`
-	Defaults    []byte     `db:"defaults"`
-	Webhooks    []byte     `db:"webhooks"`
+	ID          string         `db:"id"`
+	Name        string         `db:"name"`
+	Description string         `db:"description"`
+	Tags        pq.StringArray `db:"tags"`
+	State       string         `db:"state"`
+	CreatedAt   time.Time      `db:"created_at"`
+	CreatedBy   string         `db:"created_by"`
+	StartedAt   *time.Time     `db:"started_at"`
+	CompletedAt *time.Time     `db:"completed_at"`
+	FailedAt    *time.Time     `db:"failed_at"`
+	Tasks       []byte         `db:"tasks"`
+	Position    int            `db:"position"`
+	Inputs      []byte         `db:"inputs"`
+	Context     []byte         `db:"context"`
+	ParentID    string         `db:"parent_id"`
+	TaskCount   int            `db:"task_count"`
+	Output      string         `db:"output_"`
+	Result      string         `db:"result"`
+	Error       string         `db:"error_"`
+	TS          string         `db:"ts"`
+	Defaults    []byte         `db:"defaults"`
+	Webhooks    []byte         `db:"webhooks"`
 }
 
 type nodeRecord struct {
@@ -275,6 +276,7 @@ func (r jobRecord) toJob(tasks, execution []*tork.Task, createdBy *tork.User) (*
 	return &tork.Job{
 		ID:          r.ID,
 		Name:        r.Name,
+		Tags:        r.Tags,
 		State:       tork.JobState(r.State),
 		CreatedAt:   r.CreatedAt,
 		CreatedBy:   createdBy,

--- a/db/postgres/schema.go
+++ b/db/postgres/schema.go
@@ -30,6 +30,7 @@ insert into users (SELECT REPLACE(gen_random_uuid()::text, '-', ''),'Guest','gue
 CREATE TABLE jobs (
     id            varchar(32) not null primary key,
     name          varchar(256),
+    tags          text[]      not null default '{}',
     state         varchar(10) not null,
     created_at    timestamp   not null,
 	created_by    varchar(32) not null references users(id),
@@ -62,6 +63,7 @@ ALTER TABLE jobs ADD COLUMN ts tsvector NOT NULL
 
 CREATE INDEX jobs_ts_idx ON jobs USING GIN (ts);
 
+create index jobs_tags_idx on jobs using gin (tags);
 
 CREATE TABLE tasks (
     id            varchar(32) not null primary key,

--- a/input/job.go
+++ b/input/job.go
@@ -12,6 +12,7 @@ type Job struct {
 	id          string
 	Name        string            `json:"name,omitempty" yaml:"name,omitempty" validate:"required"`
 	Description string            `json:"description,omitempty" yaml:"description,omitempty"`
+	Tags        []string          `json:"tags,omitempty" yaml:"tags,omitempty"`
 	Tasks       []Task            `json:"tasks,omitempty" yaml:"tasks,omitempty" validate:"required,min=1,dive"`
 	Inputs      map[string]string `json:"inputs,omitempty" yaml:"inputs,omitempty"`
 	Output      string            `json:"output,omitempty" yaml:"output,omitempty" validate:"expr"`
@@ -46,6 +47,7 @@ func (ji *Job) ToJob() *tork.Job {
 	j.ID = ji.ID()
 	j.Description = ji.Description
 	j.Inputs = ji.Inputs
+	j.Tags = ji.Tags
 	j.Name = ji.Name
 	tasks := make([]*tork.Task, len(ji.Tasks))
 	for i, ti := range ji.Tasks {

--- a/internal/slices/slices.go
+++ b/internal/slices/slices.go
@@ -1,0 +1,17 @@
+package slices
+
+func Intersect[T comparable](a []T, b []T) bool {
+	elements := make(map[T]struct{})
+
+	for _, item := range a {
+		elements[item] = struct{}{}
+	}
+
+	for _, item := range b {
+		if _, found := elements[item]; found {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/slices/slirces_test.go
+++ b/internal/slices/slirces_test.go
@@ -1,0 +1,27 @@
+package slices
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHasIntersection(t *testing.T) {
+	tests := []struct {
+		slice1 []int
+		slice2 []int
+		want   bool
+	}{
+		{slice1: []int{1, 2, 3, 4, 5}, slice2: []int{4, 5, 6, 7, 8}, want: true},
+		{slice1: []int{1, 2, 3, 4, 5}, slice2: []int{6, 7, 8, 9, 10}, want: false},
+		{slice1: []int{}, slice2: []int{1, 2, 3}, want: false},
+		{slice1: []int{1, 2, 3}, slice2: []int{}, want: false},
+		{slice1: []int{}, slice2: []int{}, want: false},
+		{slice1: []int{1, 2, 3}, slice2: []int{3, 4, 5}, want: true},
+	}
+
+	for _, tt := range tests {
+		got := Intersect(tt.slice1, tt.slice2)
+		assert.Equal(t, tt.want, got)
+	}
+}

--- a/job.go
+++ b/job.go
@@ -23,6 +23,7 @@ type Job struct {
 	ParentID    string            `json:"parentId,omitempty"`
 	Name        string            `json:"name,omitempty"`
 	Description string            `json:"description,omitempty"`
+	Tags        []string          `json:"tags,omitempty"`
 	State       JobState          `json:"state,omitempty"`
 	CreatedAt   time.Time         `json:"createdAt,omitempty"`
 	CreatedBy   *User             `json:"createdBy,omitempty"`
@@ -49,6 +50,7 @@ type JobSummary struct {
 	Inputs      map[string]string `json:"inputs,omitempty"`
 	Name        string            `json:"name,omitempty"`
 	Description string            `json:"description,omitempty"`
+	Tags        []string          `json:"tags,omitempty"`
 	State       JobState          `json:"state,omitempty"`
 	CreatedAt   time.Time         `json:"createdAt,omitempty"`
 	StartedAt   *time.Time        `json:"startedAt,omitempty"`
@@ -93,6 +95,7 @@ func (j *Job) Clone() *Job {
 		ID:          j.ID,
 		Name:        j.Name,
 		Description: j.Description,
+		Tags:        j.Tags,
 		State:       j.State,
 		CreatedAt:   j.CreatedAt,
 		CreatedBy:   createdBy,
@@ -151,6 +154,7 @@ func NewJobSummary(j *Job) *JobSummary {
 		ParentID:    j.ParentID,
 		Name:        j.Name,
 		Description: j.Description,
+		Tags:        j.Tags,
 		Inputs:      maps.Clone(j.Inputs),
 		State:       j.State,
 		CreatedAt:   j.CreatedAt,


### PR DESCRIPTION
This PR adds the ability to assign `tags` to a job. Example:

```yaml
name: my job
tags:
  - tag1
  - tag2
tasks:
  - name: my first task
    run: echo -n hello world
    image: alpine:3.18.3
```
These tags can later be used to filter jobs when calling the search jobs endpoint:

```
GET /jobs?q=tag:tag1
```
Will match any jobs that is assigned the `tag1` tag.
```
GET /jobs?q=tags:tag1,tag3
```
Will match any jobs that has **at least one** of the listed `tags`