### PR TITLE
Feature: roles & permissions

### DIFF
--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -14,6 +14,7 @@ var (
 	ErrNodeNotFound    = errors.New("node not found")
 	ErrJobNotFound     = errors.New("job not found")
 	ErrUserNotFound    = errors.New("user not found")
+	ErrRoleNotFound    = errors.New("role not found")
 	ErrContextNotFound = errors.New("context not found")
 )
 
@@ -39,10 +40,17 @@ type Datastore interface {
 	UpdateJob(ctx context.Context, id string, modify func(u *tork.Job) error) error
 	GetJobByID(ctx context.Context, id string) (*tork.Job, error)
 	GetJobLogParts(ctx context.Context, jobID string, page, size int) (*Page[*tork.TaskLogPart], error)
-	GetJobs(ctx context.Context, q string, page, size int) (*Page[*tork.JobSummary], error)
+	GetJobs(ctx context.Context, currentUser, q string, page, size int) (*Page[*tork.JobSummary], error)
 
 	CreateUser(ctx context.Context, u *tork.User) error
 	GetUser(ctx context.Context, username string) (*tork.User, error)
+
+	CreateRole(ctx context.Context, r *tork.Role) error
+	GetRole(ctx context.Context, id string) (*tork.Role, error)
+	GetRoles(ctx context.Context) ([]*tork.Role, error)
+	GetUserRoles(ctx context.Context, userID string) ([]*tork.Role, error)
+	AssignRole(ctx context.Context, userID, roleID string) error
+	UnassignRole(ctx context.Context, userID, roleID string) error
 
 	GetMetrics(ctx context.Context) (*tork.Metrics, error)
 

--- a/datastore/inmemory/inmemory_test.go
+++ b/datastore/inmemory/inmemory_test.go
@@ -512,16 +512,77 @@ func TestInMemoryGetJobLogParts(t *testing.T) {
 func TestInMemorySearchJobs(t *testing.T) {
 	ctx := context.Background()
 	ds := inmemory.NewInMemoryDatastore()
-	for i := 0; i < 101; i++ {
+
+	u1 := &tork.User{
+		ID:       uuid.NewUUID(),
+		Username: uuid.NewShortUUID(),
+		Name:     "Tester",
+	}
+	err := ds.CreateUser(ctx, u1)
+	assert.NoError(t, err)
+
+	u2 := &tork.User{
+		ID:       uuid.NewUUID(),
+		Username: uuid.NewShortUUID(),
+		Name:     "Tester",
+	}
+	err = ds.CreateUser(ctx, u2)
+	assert.NoError(t, err)
+
+	r := &tork.Role{
+		Slug: "test-role",
+		Name: "Test Role",
+	}
+	err = ds.CreateRole(ctx, r)
+	assert.NoError(t, err)
+
+	err = ds.AssignRole(ctx, u2.ID, r.ID)
+	assert.NoError(t, err)
+
+	u3 := &tork.User{
+		ID:       uuid.NewUUID(),
+		Username: uuid.NewShortUUID(),
+		Name:     "Tester",
+	}
+	err = ds.CreateUser(ctx, u3)
+	assert.NoError(t, err)
+
+	for i := 0; i < 100; i++ {
 		j1 := tork.Job{
 			ID:    uuid.NewUUID(),
 			Name:  fmt.Sprintf("Job %d", (i + 1)),
 			State: tork.JobStateRunning,
-			Tasks: []*tork.Task{
-				{
-					Name: "some task",
-				},
-			},
+			Tasks: []*tork.Task{{
+				Name: "some task",
+			}},
+			Tags: []string{fmt.Sprintf("tag-%d", i)},
+			Permissions: []*tork.Permission{{
+				User: u1,
+			}, {
+				Role: r,
+			}},
+		}
+		err := ds.CreateJob(ctx, &j1)
+		assert.NoError(t, err)
+
+		now := time.Now().UTC()
+		err = ds.CreateTask(ctx, &tork.Task{
+			ID:        uuid.NewUUID(),
+			JobID:     j1.ID,
+			State:     tork.TaskStateRunning,
+			CreatedAt: &now,
+		})
+		assert.NoError(t, err)
+	}
+
+	for i := 100; i < 101; i++ {
+		j1 := tork.Job{
+			ID:    uuid.NewUUID(),
+			Name:  fmt.Sprintf("Job %d", (i + 1)),
+			State: tork.JobStateRunning,
+			Tasks: []*tork.Task{{
+				Name: "some task",
+			}},
 			Tags: []string{fmt.Sprintf("tag-%d", i)},
 		}
 		err := ds.CreateJob(ctx, &j1)
@@ -537,38 +598,100 @@ func TestInMemorySearchJobs(t *testing.T) {
 		assert.NoError(t, err)
 	}
 
-	p1, err := ds.GetJobs(ctx, "", 1, 10)
+	p1, err := ds.GetJobs(ctx, "", "", 1, 10)
 	assert.NoError(t, err)
 	assert.Equal(t, 10, p1.Size)
 	assert.Equal(t, 101, p1.TotalItems)
 
-	p1, err = ds.GetJobs(ctx, "101", 1, 10)
+	p1, err = ds.GetJobs(ctx, "", "101", 1, 10)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, p1.Size)
 	assert.Equal(t, 1, p1.TotalItems)
 
-	p1, err = ds.GetJobs(ctx, "tag:tag-1", 1, 10)
+	p1, err = ds.GetJobs(ctx, "", "tag:tag-1", 1, 10)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, p1.Size)
 	assert.Equal(t, 1, p1.TotalItems)
 
-	p1, err = ds.GetJobs(ctx, "tag:not-a-tag", 1, 10)
+	p1, err = ds.GetJobs(ctx, "", "tag:not-a-tag", 1, 10)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, p1.Size)
 	assert.Equal(t, 0, p1.TotalItems)
 
-	p1, err = ds.GetJobs(ctx, "tags:not-a-tag,tag-1", 1, 10)
+	p1, err = ds.GetJobs(ctx, "", "tags:not-a-tag,tag-1", 1, 10)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, p1.Size)
 	assert.Equal(t, 1, p1.TotalItems)
 
-	p1, err = ds.GetJobs(ctx, "Job", 1, 10)
+	p1, err = ds.GetJobs(ctx, "", "Job", 1, 10)
 	assert.NoError(t, err)
 	assert.Equal(t, 10, p1.Size)
 	assert.Equal(t, 101, p1.TotalItems)
 
-	p1, err = ds.GetJobs(ctx, "running", 1, 10)
+	p1, err = ds.GetJobs(ctx, "", "running", 1, 10)
 	assert.NoError(t, err)
 	assert.Equal(t, 10, p1.Size)
 	assert.Equal(t, 101, p1.TotalItems)
+
+	p1, err = ds.GetJobs(ctx, u1.Username, "running", 1, 10)
+	assert.NoError(t, err)
+	assert.Equal(t, 10, p1.Size)
+	assert.Equal(t, 101, p1.TotalItems)
+
+	p1, err = ds.GetJobs(ctx, u2.Username, "running", 1, 10)
+	assert.NoError(t, err)
+	assert.Equal(t, 10, p1.Size)
+	assert.Equal(t, 101, p1.TotalItems)
+
+	p1, err = ds.GetJobs(ctx, u3.Username, "running", 1, 10)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, p1.Size)
+	assert.Equal(t, 1, p1.TotalItems)
+}
+
+func TestInMemoryCreateRole(t *testing.T) {
+	ctx := context.Background()
+	ds := inmemory.NewInMemoryDatastore()
+	now := time.Now().UTC()
+	r := &tork.Role{
+		ID:        uuid.NewUUID(),
+		Slug:      "test-role",
+		Name:      "Test Role",
+		CreatedAt: &now,
+	}
+	err := ds.CreateRole(ctx, r)
+	assert.NoError(t, err)
+
+	role, err := ds.GetRole(ctx, r.Slug)
+	assert.NoError(t, err)
+	assert.Equal(t, r.Slug, role.Slug)
+
+	roles, err := ds.GetRoles(ctx)
+	assert.NoError(t, err)
+	assert.Len(t, roles, 1)
+	assert.Equal(t, "Test Role", roles[0].Name)
+
+	u := &tork.User{
+		ID:        uuid.NewUUID(),
+		Username:  uuid.NewShortUUID(),
+		Name:      "Tester",
+		CreatedAt: &now,
+	}
+	err = ds.CreateUser(ctx, u)
+	assert.NoError(t, err)
+
+	err = ds.AssignRole(ctx, u.ID, r.ID)
+	assert.NoError(t, err)
+
+	uroles, err := ds.GetUserRoles(ctx, u.ID)
+	assert.NoError(t, err)
+	assert.Len(t, uroles, 1)
+	assert.Equal(t, r.ID, uroles[0].ID)
+
+	err = ds.UnassignRole(ctx, u.ID, r.ID)
+	assert.NoError(t, err)
+
+	uroles, err = ds.GetUserRoles(ctx, u.ID)
+	assert.NoError(t, err)
+	assert.Len(t, uroles, 0)
 }

--- a/datastore/postgres/record.go
+++ b/datastore/postgres/record.go
@@ -77,6 +77,14 @@ type jobRecord struct {
 	Webhooks    []byte         `db:"webhooks"`
 }
 
+type jobPermRecord struct {
+	ID        string    `db:"id"`
+	JobID     string    `db:"job_id"`
+	UserID    *string   `db:"user_id"`
+	RoleID    *string   `db:"role_id"`
+	CreatedAt time.Time `db:"created_at"`
+}
+
 type nodeRecord struct {
 	ID              string    `db:"id"`
 	Name            string    `db:"name"`
@@ -105,6 +113,13 @@ type userRecord struct {
 	Password  string    `db:"password_"`
 	CreatedAt time.Time `db:"created_at"`
 	Disabled  bool      `db:"is_disabled"`
+}
+
+type roleRecord struct {
+	ID        string    `db:"id"`
+	Slug      string    `db:"slug"`
+	Name      string    `db:"name"`
+	CreatedAt time.Time `db:"created_at"`
 }
 
 func (r taskRecord) toTask() (*tork.Task, error) {
@@ -253,7 +268,7 @@ func (r taskLogPartRecord) toTaskLogPart() *tork.TaskLogPart {
 	}
 }
 
-func (r jobRecord) toJob(tasks, execution []*tork.Task, createdBy *tork.User) (*tork.Job, error) {
+func (r jobRecord) toJob(tasks, execution []*tork.Task, createdBy *tork.User, perms []*tork.Permission) (*tork.Job, error) {
 	var c tork.JobContext
 	if err := json.Unmarshal(r.Context, &c); err != nil {
 		return nil, errors.Wrapf(err, "error deserializing job.context")
@@ -296,6 +311,7 @@ func (r jobRecord) toJob(tasks, execution []*tork.Task, createdBy *tork.User) (*
 		Error:       r.Error,
 		Defaults:    defaults,
 		Webhooks:    webhooks,
+		Permissions: perms,
 	}, nil
 }
 
@@ -307,6 +323,16 @@ func (r userRecord) toUser() *tork.User {
 		PasswordHash: r.Password,
 		CreatedAt:    &r.CreatedAt,
 		Disabled:     r.Disabled,
+	}
+	return &n
+}
+
+func (r roleRecord) toRole() *tork.Role {
+	n := tork.Role{
+		ID:        r.ID,
+		Slug:      r.Slug,
+		Name:      r.Name,
+		CreatedAt: &r.CreatedAt,
 	}
 	return &n
 }

--- a/input/job.go
+++ b/input/job.go
@@ -18,6 +18,7 @@ type Job struct {
 	Output      string            `json:"output,omitempty" yaml:"output,omitempty" validate:"expr"`
 	Defaults    *Defaults         `json:"defaults,omitempty" yaml:"defaults,omitempty"`
 	Webhooks    []Webhook         `json:"webhooks,omitempty" yaml:"webhooks,omitempty" validate:"dive"`
+	Permissions []Permission      `json:"permissions,omitempty" yaml:"permissions,omitempty" validate:"dive"`
 }
 
 type Defaults struct {
@@ -32,6 +33,11 @@ type Webhook struct {
 	URL     string            `json:"url,omitempty" yaml:"url,omitempty" validate:"required"`
 	Headers map[string]string `json:"headers,omitempty" yaml:"headers,omitempty"`
 	Event   string            `json:"event,omitempty" yaml:"event,omitempty"`
+}
+
+type Permission struct {
+	User string `json:"user,omitempty" yaml:"user,omitempty"`
+	Role string `json:"role,omitempty" yaml:"role,omitempty"`
 }
 
 func (ji *Job) ID() string {
@@ -72,6 +78,11 @@ func (ji *Job) ToJob() *tork.Job {
 		webhooks[i] = wh.toWebhook()
 	}
 	j.Webhooks = webhooks
+	perms := make([]*tork.Permission, len(ji.Permissions))
+	for i, p := range ji.Permissions {
+		perms[i] = p.toPermission()
+	}
+	j.Permissions = perms
 	return j
 }
 
@@ -95,4 +106,18 @@ func (w Webhook) toWebhook() *tork.Webhook {
 		Headers: maps.Clone(w.Headers),
 		Event:   w.Event,
 	}
+}
+
+func (p Permission) toPermission() *tork.Permission {
+	tp := &tork.Permission{}
+	if p.Role != "" {
+		tp.Role = &tork.Role{
+			Slug: p.Role,
+		}
+	} else {
+		tp.User = &tork.User{
+			Username: p.User,
+		}
+	}
+	return tp
 }

--- a/input/validate_test.go
+++ b/input/validate_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/go-playground/validator/v10"
 	"github.com/runabol/tork"
+	"github.com/runabol/tork/datastore/inmemory"
 	"github.com/runabol/tork/mq"
 	"github.com/stretchr/testify/assert"
 )
@@ -20,7 +21,7 @@ func TestValidateMinJob(t *testing.T) {
 			},
 		},
 	}
-	err := j.Validate()
+	err := j.Validate(inmemory.NewInMemoryDatastore())
 	assert.NoError(t, err)
 }
 
@@ -29,7 +30,7 @@ func TestValidateJobNoTasks(t *testing.T) {
 		Name:  "test job",
 		Tasks: []Task{},
 	}
-	err := j.Validate()
+	err := j.Validate(inmemory.NewInMemoryDatastore())
 	assert.Error(t, err)
 }
 
@@ -44,7 +45,7 @@ func TestValidateQueue(t *testing.T) {
 			},
 		},
 	}
-	err := j.Validate()
+	err := j.Validate(inmemory.NewInMemoryDatastore())
 	assert.NoError(t, err)
 
 	j = Job{
@@ -57,7 +58,7 @@ func TestValidateQueue(t *testing.T) {
 			},
 		},
 	}
-	err = j.Validate()
+	err = j.Validate(inmemory.NewInMemoryDatastore())
 	assert.Error(t, err)
 
 	j = Job{
@@ -70,7 +71,7 @@ func TestValidateQueue(t *testing.T) {
 			},
 		},
 	}
-	err = j.Validate()
+	err = j.Validate(inmemory.NewInMemoryDatastore())
 	assert.Error(t, err)
 }
 
@@ -83,7 +84,7 @@ func TestValidateJobNoName(t *testing.T) {
 			},
 		},
 	}
-	err := j.Validate()
+	err := j.Validate(inmemory.NewInMemoryDatastore())
 	assert.Error(t, err)
 }
 
@@ -97,7 +98,7 @@ func TestValidateVar(t *testing.T) {
 			},
 		},
 	}
-	err := j.Validate()
+	err := j.Validate(inmemory.NewInMemoryDatastore())
 	assert.NoError(t, err)
 
 	j = Job{
@@ -109,7 +110,7 @@ func TestValidateVar(t *testing.T) {
 			},
 		},
 	}
-	err = j.Validate()
+	err = j.Validate(inmemory.NewInMemoryDatastore())
 	assert.NoError(t, err)
 
 	j = Job{
@@ -121,7 +122,7 @@ func TestValidateVar(t *testing.T) {
 			},
 		},
 	}
-	err = j.Validate()
+	err = j.Validate(inmemory.NewInMemoryDatastore())
 	assert.Error(t, err)
 }
 
@@ -138,7 +139,7 @@ func TestValidateJobDefaults(t *testing.T) {
 			Timeout: "1234",
 		},
 	}
-	err := j.Validate()
+	err := j.Validate(inmemory.NewInMemoryDatastore())
 	assert.Error(t, err)
 	errs := err.(validator.ValidationErrors)
 	assert.Equal(t, "Timeout", errs[0].Field())
@@ -153,7 +154,7 @@ func TestValidateJobTaskNoName(t *testing.T) {
 			},
 		},
 	}
-	err := j.Validate()
+	err := j.Validate(inmemory.NewInMemoryDatastore())
 	assert.Error(t, err)
 }
 
@@ -166,7 +167,7 @@ func TestValidateJobTaskNoImage(t *testing.T) {
 			},
 		},
 	}
-	err := j.Validate()
+	err := j.Validate(inmemory.NewInMemoryDatastore())
 	assert.NoError(t, err)
 }
 
@@ -183,7 +184,7 @@ func TestValidateJobTaskRetry(t *testing.T) {
 			},
 		},
 	}
-	err := j.Validate()
+	err := j.Validate(inmemory.NewInMemoryDatastore())
 	assert.NoError(t, err)
 
 	j = Job{
@@ -198,7 +199,7 @@ func TestValidateJobTaskRetry(t *testing.T) {
 			},
 		},
 	}
-	err = j.Validate()
+	err = j.Validate(inmemory.NewInMemoryDatastore())
 	assert.Error(t, err)
 }
 
@@ -213,7 +214,7 @@ func TestValidateJobTaskTimeout(t *testing.T) {
 			},
 		},
 	}
-	err := j.Validate()
+	err := j.Validate(inmemory.NewInMemoryDatastore())
 	assert.NoError(t, err)
 }
 
@@ -236,7 +237,7 @@ func TestValidateSubJob(t *testing.T) {
 			},
 		},
 	}
-	err := j.Validate()
+	err := j.Validate(inmemory.NewInMemoryDatastore())
 	assert.NoError(t, err)
 }
 
@@ -259,7 +260,7 @@ func TestValidateSubJobBadWebhook(t *testing.T) {
 			},
 		},
 	}
-	err := j.Validate()
+	err := j.Validate(inmemory.NewInMemoryDatastore())
 	assert.Error(t, err)
 }
 
@@ -279,7 +280,7 @@ func TestValidateParallelOrEachTaskType(t *testing.T) {
 			},
 		},
 	}
-	err := j.Validate()
+	err := j.Validate(inmemory.NewInMemoryDatastore())
 	assert.NoError(t, err)
 
 	j = Job{
@@ -298,7 +299,7 @@ func TestValidateParallelOrEachTaskType(t *testing.T) {
 			},
 		},
 	}
-	err = j.Validate()
+	err = j.Validate(inmemory.NewInMemoryDatastore())
 	assert.NoError(t, err)
 
 	j = Job{
@@ -326,7 +327,7 @@ func TestValidateParallelOrEachTaskType(t *testing.T) {
 			},
 		},
 	}
-	err = j.Validate()
+	err = j.Validate(inmemory.NewInMemoryDatastore())
 	assert.Error(t, err)
 }
 
@@ -347,7 +348,7 @@ func TestValidateParallelOrSubJobTaskType(t *testing.T) {
 			},
 		},
 	}
-	err := j.Validate()
+	err := j.Validate(inmemory.NewInMemoryDatastore())
 	assert.NoError(t, err)
 
 	j = Job{
@@ -374,7 +375,7 @@ func TestValidateParallelOrSubJobTaskType(t *testing.T) {
 			},
 		},
 	}
-	err = j.Validate()
+	err = j.Validate(inmemory.NewInMemoryDatastore())
 	assert.Error(t, err)
 }
 
@@ -394,7 +395,7 @@ func TestValidateExpr(t *testing.T) {
 			},
 		},
 	}
-	err := j.Validate()
+	err := j.Validate(inmemory.NewInMemoryDatastore())
 	assert.NoError(t, err)
 
 	j = Job{
@@ -412,7 +413,7 @@ func TestValidateExpr(t *testing.T) {
 			},
 		},
 	}
-	err = j.Validate()
+	err = j.Validate(inmemory.NewInMemoryDatastore())
 	assert.NoError(t, err)
 
 	j = Job{
@@ -430,7 +431,7 @@ func TestValidateExpr(t *testing.T) {
 			},
 		},
 	}
-	err = j.Validate()
+	err = j.Validate(inmemory.NewInMemoryDatastore())
 	assert.Error(t, err)
 }
 
@@ -451,7 +452,7 @@ func TestValidateMounts(t *testing.T) {
 			},
 		},
 	}
-	err := j.Validate()
+	err := j.Validate(inmemory.NewInMemoryDatastore())
 	assert.Error(t, err)
 
 	j = Job{
@@ -470,7 +471,7 @@ func TestValidateMounts(t *testing.T) {
 			},
 		},
 	}
-	err = j.Validate()
+	err = j.Validate(inmemory.NewInMemoryDatastore())
 	assert.NoError(t, err)
 
 	j = Job{
@@ -489,7 +490,7 @@ func TestValidateMounts(t *testing.T) {
 			},
 		},
 	}
-	err = j.Validate()
+	err = j.Validate(inmemory.NewInMemoryDatastore())
 	assert.NoError(t, err)
 
 	j = Job{
@@ -509,7 +510,7 @@ func TestValidateMounts(t *testing.T) {
 			},
 		},
 	}
-	err = j.Validate()
+	err = j.Validate(inmemory.NewInMemoryDatastore())
 	assert.Error(t, err)
 
 	j = Job{
@@ -529,7 +530,7 @@ func TestValidateMounts(t *testing.T) {
 			},
 		},
 	}
-	err = j.Validate()
+	err = j.Validate(inmemory.NewInMemoryDatastore())
 	assert.NoError(t, err)
 
 	j = Job{
@@ -549,7 +550,7 @@ func TestValidateMounts(t *testing.T) {
 			},
 		},
 	}
-	err = j.Validate()
+	err = j.Validate(inmemory.NewInMemoryDatastore())
 	assert.Error(t, err)
 
 	j = Job{
@@ -569,7 +570,7 @@ func TestValidateMounts(t *testing.T) {
 			},
 		},
 	}
-	err = j.Validate()
+	err = j.Validate(inmemory.NewInMemoryDatastore())
 	assert.Error(t, err)
 
 	j = Job{
@@ -589,7 +590,7 @@ func TestValidateMounts(t *testing.T) {
 			},
 		},
 	}
-	err = j.Validate()
+	err = j.Validate(inmemory.NewInMemoryDatastore())
 	assert.Error(t, err)
 
 	j = Job{
@@ -609,7 +610,7 @@ func TestValidateMounts(t *testing.T) {
 			},
 		},
 	}
-	err = j.Validate()
+	err = j.Validate(inmemory.NewInMemoryDatastore())
 	assert.Error(t, err)
 }
 
@@ -626,7 +627,7 @@ func TestValidateWebhook(t *testing.T) {
 			},
 		},
 	}
-	err := j.Validate()
+	err := j.Validate(inmemory.NewInMemoryDatastore())
 	assert.NoError(t, err)
 
 	j = Job{
@@ -641,6 +642,6 @@ func TestValidateWebhook(t *testing.T) {
 			},
 		},
 	}
-	err = j.Validate()
+	err = j.Validate(inmemory.NewInMemoryDatastore())
 	assert.Error(t, err)
 }

--- a/job.go
+++ b/job.go
@@ -41,6 +41,7 @@ type Job struct {
 	Error       string            `json:"error,omitempty"`
 	Defaults    *JobDefaults      `json:"defaults,omitempty"`
 	Webhooks    []*Webhook        `json:"webhooks,omitempty"`
+	Permissions []*Permission     `json:"permissions,omitempty"`
 }
 
 type JobSummary struct {
@@ -60,6 +61,11 @@ type JobSummary struct {
 	TaskCount   int               `json:"taskCount,omitempty"`
 	Result      string            `json:"result,omitempty"`
 	Error       string            `json:"error,omitempty"`
+}
+
+type Permission struct {
+	Role *Role `json:"role,omitempty"`
+	User *User `json:"user,omitempty"`
 }
 
 type JobContext struct {
@@ -114,6 +120,7 @@ func (j *Job) Clone() *Job {
 		Error:       j.Error,
 		Defaults:    defaults,
 		Webhooks:    CloneWebhooks(j.Webhooks),
+		Permissions: ClonePermissions(j.Permissions),
 	}
 }
 
@@ -176,10 +183,28 @@ func CloneWebhooks(webhooks []*Webhook) []*Webhook {
 	return copy
 }
 
-func (w Webhook) Clone() *Webhook {
+func (w *Webhook) Clone() *Webhook {
 	return &Webhook{
 		URL:     w.URL,
 		Headers: maps.Clone(w.Headers),
 		Event:   w.Event,
 	}
+}
+
+func ClonePermissions(perms []*Permission) []*Permission {
+	copy := make([]*Permission, len(perms))
+	for i, p := range perms {
+		copy[i] = p.Clone()
+	}
+	return copy
+}
+
+func (p *Permission) Clone() *Permission {
+	c := &Permission{}
+	if p.Role != nil {
+		c.Role = p.Role.Clone()
+	} else {
+		c.User = p.User.Clone()
+	}
+	return c
 }

--- a/role.go
+++ b/role.go
@@ -1,0 +1,30 @@
+package tork
+
+import "time"
+
+const (
+	ROLE_PUBLIC string = "public"
+)
+
+type Role struct {
+	ID        string     `json:"id,omitempty"`
+	Slug      string     `json:"slug,omitempty"`
+	Name      string     `json:"name,omitempty"`
+	CreatedAt *time.Time `json:"createdAt,omitempty"`
+}
+
+func (r *Role) Clone() *Role {
+	return &Role{
+		ID:        r.ID,
+		Slug:      r.Slug,
+		Name:      r.Name,
+		CreatedAt: r.CreatedAt,
+	}
+}
+
+type UserRole struct {
+	ID        string     `json:"id,omitempty"`
+	UserID    string     `json:"userId,omitempty"`
+	RoleID    string     `json:"roleId,omitempty"`
+	CreatedAt *time.Time `json:"createdAt,omitempty"`
+}


### PR DESCRIPTION
This PR adds support for roles and permissions. 

Example:

```yaml
name: my job
permissions:
  - role: some-role # the role's slug
  - user: someuser # the user's username
...
```

Permissions specify which user(s) or role(s) should have access to this particular job.

Jobs without `permissions` will be viewable to all as they are now.