### PR TITLE
Feature: auto-delete jobs

### DIFF
--- a/db/postgres/schema.go
+++ b/db/postgres/schema.go
@@ -56,6 +56,7 @@ CREATE TABLE jobs (
 	created_by    varchar(32) not null references users(id),
     started_at    timestamp,
     completed_at  timestamp,
+	delete_at     timestamp,
     failed_at     timestamp,
     tasks         jsonb       not null,
     position      int         not null,
@@ -68,7 +69,8 @@ CREATE TABLE jobs (
     result        text,
     error_        text,
     defaults      jsonb,
-    webhooks      jsonb
+    webhooks      jsonb,
+	auto_delete   jsonb
 );
 
 CREATE INDEX idx_jobs_state ON jobs (state);

--- a/input/job.go
+++ b/input/job.go
@@ -19,6 +19,7 @@ type Job struct {
 	Defaults    *Defaults         `json:"defaults,omitempty" yaml:"defaults,omitempty"`
 	Webhooks    []Webhook         `json:"webhooks,omitempty" yaml:"webhooks,omitempty" validate:"dive"`
 	Permissions []Permission      `json:"permissions,omitempty" yaml:"permissions,omitempty" validate:"dive"`
+	AutoDelete  *AutoDelete       `json:"autoDelete,omitempty" yaml:"autoDelete,omitempty"`
 }
 
 type Defaults struct {
@@ -27,6 +28,10 @@ type Defaults struct {
 	Timeout  string  `json:"timeout,omitempty" yaml:"timeout,omitempty" validate:"duration"`
 	Queue    string  `json:"queue,omitempty" yaml:"queue,omitempty" validate:"queue"`
 	Priority int     `json:"priority,omitempty" yaml:"priority,omitempty" validate:"min=0,max=9"`
+}
+
+type AutoDelete struct {
+	After string `json:"after,omitempty" yaml:"after,omitempty" validate:"duration"`
 }
 
 type Webhook struct {
@@ -83,6 +88,11 @@ func (ji *Job) ToJob() *tork.Job {
 		perms[i] = p.toPermission()
 	}
 	j.Permissions = perms
+	if ji.AutoDelete != nil {
+		j.AutoDelete = &tork.AutoDelete{
+			After: ji.AutoDelete.After,
+		}
+	}
 	return j
 }
 

--- a/internal/coordinator/handlers/job.go
+++ b/internal/coordinator/handlers/job.go
@@ -108,6 +108,16 @@ func (h *jobHandler) completeJob(ctx context.Context, j *tork.Job) error {
 			u.CompletedAt = &now
 			u.Result = result
 			j.Result = result
+			if j.AutoDelete != nil && j.AutoDelete.After != "" {
+				dur, err := time.ParseDuration(j.AutoDelete.After)
+				if err != nil {
+					log.Error().Err(err).Msgf("unable to parse auto delete duration: %s", j.AutoDelete.After)
+				} else {
+					deleteAt := time.Now().UTC().Add(dur)
+					u.DeleteAt = &deleteAt
+					j.DeleteAt = &deleteAt
+				}
+			}
 		}
 		return nil
 	}); err != nil {

--- a/job.go
+++ b/job.go
@@ -42,6 +42,8 @@ type Job struct {
 	Defaults    *JobDefaults      `json:"defaults,omitempty"`
 	Webhooks    []*Webhook        `json:"webhooks,omitempty"`
 	Permissions []*Permission     `json:"permissions,omitempty"`
+	AutoDelete  *AutoDelete       `json:"autoDelete,omitempty"`
+	DeleteAt    *time.Time        `json:"deleteAt,omitempty"`
 }
 
 type JobSummary struct {
@@ -66,6 +68,10 @@ type JobSummary struct {
 type Permission struct {
 	Role *Role `json:"role,omitempty"`
 	User *User `json:"user,omitempty"`
+}
+
+type AutoDelete struct {
+	After string `json:"after,omitempty"`
 }
 
 type JobContext struct {
@@ -97,6 +103,10 @@ func (j *Job) Clone() *Job {
 	if j.CreatedBy != nil {
 		createdBy = j.CreatedBy.Clone()
 	}
+	var autoDelete *AutoDelete
+	if j.AutoDelete != nil {
+		autoDelete = j.AutoDelete.Clone()
+	}
 	return &Job{
 		ID:          j.ID,
 		Name:        j.Name,
@@ -121,6 +131,7 @@ func (j *Job) Clone() *Job {
 		Defaults:    defaults,
 		Webhooks:    CloneWebhooks(j.Webhooks),
 		Permissions: ClonePermissions(j.Permissions),
+		AutoDelete:  autoDelete,
 	}
 }
 
@@ -207,4 +218,10 @@ func (p *Permission) Clone() *Permission {
 		c.User = p.User.Clone()
 	}
 	return c
+}
+
+func (a *AutoDelete) Clone() *AutoDelete {
+	return &AutoDelete{
+		After: a.After,
+	}
 }


### PR DESCRIPTION
This PR adds support for the automatic deletion of `COMPLETED` jobs. 

Example:
```yaml
name: my job
autoDelete: 
  after: 5m
tasks:
  ...
```

Indicates that this job is to be deleted after at least 5 minutes after it has transitioned to a `COMPLETED` state has elapsed.