### PR TITLE
Feature: secrets

### DIFF
--- a/datastore/postgres/postgres_test.go
+++ b/datastore/postgres/postgres_test.go
@@ -87,6 +87,9 @@ func TestPostgresCreateJob(t *testing.T) {
 		AutoDelete: &tork.AutoDelete{
 			After: "5h",
 		},
+		Secrets: map[string]string{
+			"password": "secret",
+		},
 	}
 	err = ds.CreateJob(ctx, &j1)
 	assert.NoError(t, err)
@@ -97,6 +100,7 @@ func TestPostgresCreateJob(t *testing.T) {
 	assert.Equal(t, u.Username, j2.CreatedBy.Username)
 	assert.Equal(t, []string{"tag-a", "tag-b"}, j2.Tags)
 	assert.Equal(t, "5h", j2.AutoDelete.After)
+	assert.Equal(t, map[string]string{"password": "secret"}, j2.Secrets)
 }
 
 func TestPostgresCreateAndGetParallelTask(t *testing.T) {

--- a/datastore/postgres/record.go
+++ b/datastore/postgres/record.go
@@ -77,6 +77,7 @@ type jobRecord struct {
 	Defaults    []byte         `db:"defaults"`
 	Webhooks    []byte         `db:"webhooks"`
 	AutoDelete  []byte         `db:"auto_delete"`
+	Secrets     []byte         `db:"secrets"`
 }
 
 type jobPermRecord struct {
@@ -297,6 +298,12 @@ func (r jobRecord) toJob(tasks, execution []*tork.Task, createdBy *tork.User, pe
 	if err := json.Unmarshal(r.Webhooks, &webhooks); err != nil {
 		return nil, errors.Wrapf(err, "error deserializing job.webhook")
 	}
+	var secrets map[string]string
+	if r.Secrets != nil {
+		if err := json.Unmarshal(r.Secrets, &secrets); err != nil {
+			return nil, errors.Wrapf(err, "error deserializing job.secrets")
+		}
+	}
 	return &tork.Job{
 		ID:          r.ID,
 		Name:        r.Name,
@@ -323,6 +330,7 @@ func (r jobRecord) toJob(tasks, execution []*tork.Task, createdBy *tork.User, pe
 		Permissions: perms,
 		AutoDelete:  autoDelete,
 		DeleteAt:    r.DeleteAt,
+		Secrets:     secrets,
 	}, nil
 }
 

--- a/db/postgres/schema.go
+++ b/db/postgres/schema.go
@@ -70,7 +70,8 @@ CREATE TABLE jobs (
     error_        text,
     defaults      jsonb,
     webhooks      jsonb,
-    auto_delete   jsonb
+    auto_delete   jsonb,
+    secrets       jsonb
 );
 
 CREATE INDEX idx_jobs_state ON jobs (state);

--- a/engine/coordinator.go
+++ b/engine/coordinator.go
@@ -45,15 +45,16 @@ func (e *Engine) initCoordinator() error {
 	}
 
 	// redact
-	redactJobEnabled := conf.BoolDefault("middleware.job.redact.enabled", false)
+	redactJobEnabled := conf.BoolDefault("middleware.job.redact.enabled", true)
 	if redactJobEnabled {
 		patterns := conf.Strings("middleware.job.redact.patterns")
 		matchers := make([]redact.Matcher, len(patterns))
 		for i, pattern := range patterns {
 			matchers[i] = redact.Wildcard(pattern)
 		}
-		cfg.Middleware.Job = append(cfg.Middleware.Job, job.Redact(redact.NewRedacter(matchers...)))
-		cfg.Middleware.Task = append(cfg.Middleware.Task, task.Redact(redact.NewRedacter(matchers...)))
+		redacter := redact.NewRedacter(e.ds, matchers...)
+		cfg.Middleware.Job = append(cfg.Middleware.Job, job.Redact(redacter))
+		cfg.Middleware.Task = append(cfg.Middleware.Task, task.Redact(redacter))
 	}
 
 	// webhook middleware

--- a/input/job.go
+++ b/input/job.go
@@ -15,6 +15,7 @@ type Job struct {
 	Tags        []string          `json:"tags,omitempty" yaml:"tags,omitempty"`
 	Tasks       []Task            `json:"tasks,omitempty" yaml:"tasks,omitempty" validate:"required,min=1,dive"`
 	Inputs      map[string]string `json:"inputs,omitempty" yaml:"inputs,omitempty"`
+	Secrets     map[string]string `json:"secrets,omitempty" yaml:"secrets,omitempty"`
 	Output      string            `json:"output,omitempty" yaml:"output,omitempty" validate:"expr"`
 	Defaults    *Defaults         `json:"defaults,omitempty" yaml:"defaults,omitempty"`
 	Webhooks    []Webhook         `json:"webhooks,omitempty" yaml:"webhooks,omitempty" validate:"dive"`
@@ -58,6 +59,7 @@ func (ji *Job) ToJob() *tork.Job {
 	j.ID = ji.ID()
 	j.Description = ji.Description
 	j.Inputs = ji.Inputs
+	j.Secrets = ji.Secrets
 	j.Tags = ji.Tags
 	j.Name = ji.Name
 	tasks := make([]*tork.Task, len(ji.Tasks))
@@ -69,6 +71,7 @@ func (ji *Job) ToJob() *tork.Job {
 	j.CreatedAt = n
 	j.Context = tork.JobContext{}
 	j.Context.Inputs = ji.Inputs
+	j.Context.Secrets = ji.Secrets
 	j.Context.Job = map[string]string{
 		"id":   j.ID,
 		"name": j.Name,

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -1,9 +1,12 @@
 package redact
 
 import (
+	"context"
 	"strings"
 
+	"github.com/rs/zerolog/log"
 	"github.com/runabol/tork"
+	"github.com/runabol/tork/datastore"
 	"github.com/runabol/tork/internal/wildcard"
 )
 
@@ -13,14 +16,16 @@ const (
 
 type Redacter struct {
 	matchers []Matcher
+	ds       datastore.Datastore
 }
 
-func NewRedacter(matchers ...Matcher) *Redacter {
+func NewRedacter(ds datastore.Datastore, matchers ...Matcher) *Redacter {
 	if len(matchers) == 0 {
 		matchers = defaultMatchers
 	}
 	return &Redacter{
 		matchers: matchers,
+		ds:       ds,
 	}
 }
 
@@ -45,21 +50,30 @@ func Wildcard(pattern string) func(s string) bool {
 }
 
 func (r *Redacter) RedactTask(t *tork.Task) {
+	job, err := r.ds.GetJobByID(context.Background(), t.JobID)
+	if err != nil {
+		log.Error().Err(err).Msgf("error getting job for task %s", t.ID)
+		return
+	}
+	r.doRedactTask(t, job.Secrets)
+}
+
+func (r *Redacter) doRedactTask(t *tork.Task, secrets map[string]string) {
 	redacted := t
 	// redact env vars
-	redacted.Env = r.redactVars(redacted.Env)
+	redacted.Env = r.redactVars(redacted.Env, secrets)
 	// redact pre tasks
 	for _, p := range redacted.Pre {
-		r.RedactTask(p)
+		r.doRedactTask(p, secrets)
 	}
 	// redact post tasks
 	for _, p := range redacted.Post {
-		r.RedactTask(p)
+		r.doRedactTask(p, secrets)
 	}
 	// redact parallel tasks
 	if redacted.Parallel != nil {
 		for _, p := range redacted.Parallel.Tasks {
-			r.RedactTask(p)
+			r.doRedactTask(p, secrets)
 		}
 	}
 	// registry creds
@@ -71,33 +85,42 @@ func (r *Redacter) RedactTask(t *tork.Task) {
 func (r *Redacter) RedactJob(j *tork.Job) {
 	redacted := j
 	// redact inputs
-	redacted.Inputs = r.redactVars(redacted.Inputs)
+	redacted.Inputs = r.redactVars(redacted.Inputs, j.Secrets)
 	// redact webhook headers
 	for _, w := range j.Webhooks {
 		if w.Headers != nil {
-			w.Headers = r.redactVars(w.Headers)
+			w.Headers = r.redactVars(w.Headers, j.Secrets)
 		}
 	}
 	// redact context
-	redacted.Context.Inputs = r.redactVars(redacted.Context.Inputs)
-	redacted.Context.Tasks = r.redactVars(redacted.Context.Tasks)
+	redacted.Context.Inputs = r.redactVars(redacted.Context.Inputs, j.Secrets)
+	redacted.Context.Secrets = r.redactVars(redacted.Context.Secrets, j.Secrets)
+	redacted.Context.Tasks = r.redactVars(redacted.Context.Tasks, j.Secrets)
 	// redact tasks
 	for _, t := range redacted.Tasks {
-		r.RedactTask(t)
+		r.doRedactTask(t, j.Secrets)
 	}
 	// redact execution
 	for _, t := range redacted.Execution {
-		r.RedactTask(t)
+		r.doRedactTask(t, j.Secrets)
+	}
+	for k := range j.Secrets {
+		redacted.Secrets[k] = redactedStr
 	}
 }
 
-func (r *Redacter) redactVars(m map[string]string) map[string]string {
+func (r *Redacter) redactVars(m map[string]string, secrets map[string]string) map[string]string {
 	redacted := make(map[string]string)
 	for k, v := range m {
 		for _, m := range r.matchers {
 			if m(k) {
 				v = redactedStr
 				break
+			}
+		}
+		for _, secret := range secrets {
+			if secret == v {
+				v = redactedStr
 			}
 		}
 		redacted[k] = v

--- a/job.go
+++ b/job.go
@@ -44,6 +44,7 @@ type Job struct {
 	Permissions []*Permission     `json:"permissions,omitempty"`
 	AutoDelete  *AutoDelete       `json:"autoDelete,omitempty"`
 	DeleteAt    *time.Time        `json:"deleteAt,omitempty"`
+	Secrets     map[string]string `json:"secrets,omitempty"`
 }
 
 type JobSummary struct {
@@ -75,9 +76,10 @@ type AutoDelete struct {
 }
 
 type JobContext struct {
-	Job    map[string]string `json:"job,omitempty"`
-	Inputs map[string]string `json:"inputs,omitempty"`
-	Tasks  map[string]string `json:"tasks,omitempty"`
+	Job     map[string]string `json:"job,omitempty"`
+	Inputs  map[string]string `json:"inputs,omitempty"`
+	Secrets map[string]string `json:"secrets,omitempty"`
+	Tasks   map[string]string `json:"tasks,omitempty"`
 }
 
 type JobDefaults struct {
@@ -122,6 +124,7 @@ func (j *Job) Clone() *Job {
 		Execution:   CloneTasks(j.Execution),
 		Position:    j.Position,
 		Inputs:      maps.Clone(j.Inputs),
+		Secrets:     maps.Clone(j.Secrets),
 		Context:     j.Context.Clone(),
 		ParentID:    j.ParentID,
 		TaskCount:   j.TaskCount,
@@ -137,17 +140,19 @@ func (j *Job) Clone() *Job {
 
 func (c JobContext) Clone() JobContext {
 	return JobContext{
-		Inputs: maps.Clone(c.Inputs),
-		Tasks:  maps.Clone(c.Tasks),
-		Job:    maps.Clone(c.Job),
+		Inputs:  maps.Clone(c.Inputs),
+		Secrets: maps.Clone(c.Secrets),
+		Tasks:   maps.Clone(c.Tasks),
+		Job:     maps.Clone(c.Job),
 	}
 }
 
 func (c JobContext) AsMap() map[string]any {
 	return map[string]any{
-		"inputs": c.Inputs,
-		"tasks":  c.Tasks,
-		"job":    c.Job,
+		"inputs":  c.Inputs,
+		"secrets": c.Secrets,
+		"tasks":   c.Tasks,
+		"job":     c.Job,
 	}
 }
 

--- a/middleware/job/redact_test.go
+++ b/middleware/job/redact_test.go
@@ -5,12 +5,13 @@ import (
 	"testing"
 
 	"github.com/runabol/tork"
+	"github.com/runabol/tork/datastore/inmemory"
 	"github.com/runabol/tork/internal/redact"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestRedactOnRead(t *testing.T) {
-	hm := ApplyMiddleware(NoOpHandlerFunc, []MiddlewareFunc{Redact(redact.NewRedacter())})
+	hm := ApplyMiddleware(NoOpHandlerFunc, []MiddlewareFunc{Redact(redact.NewRedacter(inmemory.NewInMemoryDatastore()))})
 	j := &tork.Job{
 		Inputs: map[string]string{
 			"secret": "1234",
@@ -21,7 +22,7 @@ func TestRedactOnRead(t *testing.T) {
 }
 
 func TestNoRedact(t *testing.T) {
-	hm := ApplyMiddleware(NoOpHandlerFunc, []MiddlewareFunc{Redact(redact.NewRedacter())})
+	hm := ApplyMiddleware(NoOpHandlerFunc, []MiddlewareFunc{Redact(redact.NewRedacter(inmemory.NewInMemoryDatastore()))})
 	j := &tork.Job{
 		Inputs: map[string]string{
 			"secret": "1234",

--- a/middleware/task/redact_test.go
+++ b/middleware/task/redact_test.go
@@ -5,13 +5,23 @@ import (
 	"testing"
 
 	"github.com/runabol/tork"
+	"github.com/runabol/tork/datastore/inmemory"
 	"github.com/runabol/tork/internal/redact"
+	"github.com/runabol/tork/internal/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestRedactOnRead(t *testing.T) {
-	hm := ApplyMiddleware(NoOpHandlerFunc, []MiddlewareFunc{Redact(redact.NewRedacter())})
+	ds := inmemory.NewInMemoryDatastore()
+	ctx := context.Background()
+	j1 := tork.Job{
+		ID: uuid.NewUUID(),
+	}
+	err := ds.CreateJob(ctx, &j1)
+	assert.NoError(t, err)
+	hm := ApplyMiddleware(NoOpHandlerFunc, []MiddlewareFunc{Redact(redact.NewRedacter(ds))})
 	t1 := &tork.Task{
+		JobID: j1.ID,
 		Env: map[string]string{
 			"secret": "1234",
 		},
@@ -21,8 +31,16 @@ func TestRedactOnRead(t *testing.T) {
 }
 
 func TestNoRedact(t *testing.T) {
-	hm := ApplyMiddleware(NoOpHandlerFunc, []MiddlewareFunc{Redact(redact.NewRedacter())})
+	ds := inmemory.NewInMemoryDatastore()
+	ctx := context.Background()
+	j1 := tork.Job{
+		ID: uuid.NewUUID(),
+	}
+	err := ds.CreateJob(ctx, &j1)
+	assert.NoError(t, err)
+	hm := ApplyMiddleware(NoOpHandlerFunc, []MiddlewareFunc{Redact(redact.NewRedacter(ds))})
 	t1 := &tork.Task{
+		JobID: j1.ID,
 		Env: map[string]string{
 			"secret": "1234",
 		},


### PR DESCRIPTION
This PR adds first-class support for job-level secrets. 

This augments the existing key-based, pattern-matching support for redacting sensitive values.

1. Add a `secrets` namespace to the Job's Context object.
2. Turn on the redact middlewares by default.

Example:

```yaml
name: my job
secrets:
   password: "secret"
tasks:
  - name: my first task
    run: |
      echo do some work
    image: alpine:3.18.3
    env:
      SECRET: "{{secrets.password}}"
```