### PR TITLE
Feature: evaluate headers on webhooks

### DIFF
--- a/middleware/job/webhook_test.go
+++ b/middleware/job/webhook_test.go
@@ -136,8 +136,8 @@ func TestWebhookOKWithHeaders(t *testing.T) {
 		}
 		ctype := r.Header.Get("Content-Type")
 		assert.Equal(t, "application/json; charset=UTF-8", ctype)
-		val := r.Header.Get("my-header")
-		assert.Equal(t, "my-value", val)
+		assert.Equal(t, "my-value", r.Header.Get("my-header"))
+		assert.Equal(t, "1234-5678", r.Header.Get("secret"))
 		assert.Equal(t, "1234", js.ID)
 		assert.Equal(t, tork.JobStateCompleted, js.State)
 		w.WriteHeader(http.StatusOK)
@@ -147,10 +147,16 @@ func TestWebhookOKWithHeaders(t *testing.T) {
 	j := &tork.Job{
 		ID:    "1234",
 		State: tork.JobStateCompleted,
+		Context: tork.JobContext{
+			Secrets: map[string]string{
+				"some_key": "1234-5678",
+			},
+		},
 		Webhooks: []*tork.Webhook{{
 			URL: svr.URL,
 			Headers: map[string]string{
 				"my-header": "my-value",
+				"secret":    "{{secrets.some_key}}",
 			},
 		}},
 	}

--- a/middleware/task/webhook_test.go
+++ b/middleware/task/webhook_test.go
@@ -33,6 +33,8 @@ func TestWebhookOK(t *testing.T) {
 		}
 		assert.Equal(t, "2", js.ID)
 		assert.Equal(t, tork.TaskStateCompleted, js.State)
+		assert.Equal(t, "my-value", r.Header.Get("my-header"))
+		assert.Equal(t, "1234-5678", r.Header.Get("secret"))
 		w.WriteHeader(http.StatusOK)
 		received <- 1
 	}))
@@ -40,9 +42,18 @@ func TestWebhookOK(t *testing.T) {
 	j := &tork.Job{
 		ID:    "1",
 		State: tork.JobStateCompleted,
+		Context: tork.JobContext{
+			Secrets: map[string]string{
+				"some_key": "1234-5678",
+			},
+		},
 		Webhooks: []*tork.Webhook{{
 			URL:   svr.URL,
 			Event: webhook.EventTaskStateChange,
+			Headers: map[string]string{
+				"my-header": "my-value",
+				"secret":    "{{secrets.some_key}}",
+			},
 		}},
 	}
 


### PR DESCRIPTION
This PR adds support for evaluating webhook headers against the job's context. 