### PR TITLE
Feature: Service Tasks

### DIFF
--- a/datastore/postgres/postgres.go
+++ b/datastore/postgres/postgres.go
@@ -213,6 +213,15 @@ func (ds *PostgresDatastore) CreateTask(ctx context.Context, t *tork.Task) error
 		s := string(b)
 		mounts = &s
 	}
+	var ports *string
+	if t.Ports != nil {
+		b, err := json.Marshal(t.Ports)
+		if err != nil {
+			return errors.Wrapf(err, "failed to serialize task.ports")
+		}
+		s := string(b)
+		ports = &s
+	}
 	q := `insert into tasks (
 		    id, -- $1
 			job_id, -- $2
@@ -252,13 +261,14 @@ func (ds *PostgresDatastore) CreateTask(ctx context.Context, t *tork.Task) error
 			if_, -- $36
 			tags, -- $37
 			priority, -- $38
-			workdir -- $39
+			workdir, -- $39
+			ports -- $40
 		  ) 
 	      values (
 			$1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,
 		    $15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,
 			$27,$28,$29,$30,$31,$32,$33,$34,$35,$36,$37,$38,
-			$39)`
+			$39,$40)`
 	_, err = ds.exec(q,
 		t.ID,                         // $1
 		t.JobID,                      // $2
@@ -299,6 +309,7 @@ func (ds *PostgresDatastore) CreateTask(ctx context.Context, t *tork.Task) error
 		pq.StringArray(t.Tags),       // $37
 		t.Priority,                   // $38
 		t.Workdir,                    // $39
+		ports,                        // $40
 	)
 	if err != nil {
 		return errors.Wrapf(err, "error inserting task to the db")
@@ -431,10 +442,10 @@ func (ds *PostgresDatastore) UpdateTask(ctx context.Context, id string, modify f
 
 func (ds *PostgresDatastore) CreateNode(ctx context.Context, n *tork.Node) error {
 	q := `insert into nodes 
-	       (id,name,started_at,last_heartbeat_at,cpu_percent,queue,status,hostname,task_count,version_) 
+	       (id,name,started_at,last_heartbeat_at,cpu_percent,queue,status,hostname,task_count,version_,port)
 	      values
-	       ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`
-	_, err := ds.exec(q, n.ID, n.Name, n.StartedAt, n.LastHeartbeatAt, n.CPUPercent, n.Queue, n.Status, n.Hostname, n.TaskCount, n.Version)
+	       ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)`
+	_, err := ds.exec(q, n.ID, n.Name, n.StartedAt, n.LastHeartbeatAt, n.CPUPercent, n.Queue, n.Status, n.Hostname, n.TaskCount, n.Version, n.Port)
 	if err != nil {
 		return errors.Wrapf(err, "error inserting node to the db")
 	}

--- a/datastore/postgres/postgres_test.go
+++ b/datastore/postgres/postgres_test.go
@@ -47,6 +47,9 @@ func TestPostgresCreateAndGetTask(t *testing.T) {
 		Tags:        []string{"tag1", "tag2"},
 		Workdir:     "/some/dir",
 		Priority:    2,
+		Ports: []*tork.Port{{
+			Port: "1234",
+		}},
 	}
 	err = ds.CreateTask(ctx, &t1)
 	assert.NoError(t, err)
@@ -64,6 +67,7 @@ func TestPostgresCreateAndGetTask(t *testing.T) {
 	assert.Equal(t, []string([]string{"tag1", "tag2"}), t2.Tags)
 	assert.Equal(t, "/some/dir", t2.Workdir)
 	assert.Equal(t, 2, t2.Priority)
+	assert.Equal(t, "1234", t2.Ports[0].Port)
 }
 
 func TestPostgresCreateJob(t *testing.T) {
@@ -339,6 +343,7 @@ func TestPostgresCreateAndGetNode(t *testing.T) {
 		ID:       uuid.NewUUID(),
 		Name:     "some node",
 		Hostname: "some-name",
+		Port:     1234,
 		Version:  "1.0.0",
 	}
 	err = ds.CreateNode(ctx, n1)
@@ -347,6 +352,7 @@ func TestPostgresCreateAndGetNode(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, n1.ID, n2.ID)
 	assert.Equal(t, "some-name", n2.Hostname)
+	assert.Equal(t, 1234, n2.Port)
 	assert.Equal(t, "1.0.0", n2.Version)
 	assert.Equal(t, "some node", n2.Name)
 }

--- a/datastore/postgres/record.go
+++ b/datastore/postgres/record.go
@@ -51,6 +51,7 @@ type taskRecord struct {
 	Priority    int            `db:"priority"`
 	Workdir     string         `db:"workdir"`
 	Progress    float64        `db:"progress"`
+	Ports       []byte         `db:"ports"`
 }
 
 type jobRecord struct {
@@ -99,6 +100,7 @@ type nodeRecord struct {
 	Queue           string    `db:"queue"`
 	Status          string    `db:"status"`
 	Hostname        string    `db:"hostname"`
+	Port            int       `db:"port"`
 	TaskCount       int       `db:"task_count"`
 	Version         string    `db:"version_"`
 }
@@ -200,6 +202,12 @@ func (r taskRecord) toTask() (*tork.Task, error) {
 			return nil, errors.Wrapf(err, "error deserializing task.registry")
 		}
 	}
+	var ports []*tork.Port
+	if r.Ports != nil {
+		if err := json.Unmarshal(r.Ports, &ports); err != nil {
+			return nil, errors.Wrapf(err, "error deserializing task.ports")
+		}
+	}
 	return &tork.Task{
 		ID:          r.ID,
 		JobID:       r.JobID,
@@ -241,6 +249,7 @@ func (r taskRecord) toTask() (*tork.Task, error) {
 		Priority:    r.Priority,
 		Workdir:     r.Workdir,
 		Progress:    r.Progress,
+		Ports:       ports,
 	}, nil
 }
 
@@ -254,6 +263,7 @@ func (r nodeRecord) toNode() *tork.Node {
 		Queue:           r.Queue,
 		Status:          tork.NodeStatus(r.Status),
 		Hostname:        r.Hostname,
+		Port:            r.Port,
 		TaskCount:       r.TaskCount,
 		Version:         r.Version,
 	}

--- a/db/postgres/schema.go
+++ b/db/postgres/schema.go
@@ -10,6 +10,7 @@ CREATE TABLE nodes (
     cpu_percent        float        not null,
     status             varchar(10)  not null,
     hostname           varchar(128) not null,
+    port               int          not null,
     task_count         int          not null,
     version_           varchar(32)  not null
 );
@@ -141,7 +142,8 @@ CREATE TABLE tasks (
     tags          text[],
     priority      int,
     workdir       varchar(256),
-    progress      numeric(5,2) default 0
+    progress      numeric(5,2) default 0,
+    ports         jsonb
 );
 
 CREATE INDEX idx_tasks_state ON tasks (state);

--- a/engine/coordinator.go
+++ b/engine/coordinator.go
@@ -157,6 +157,7 @@ func logger() echo.MiddlewareFunc {
 		LogRemoteIP: true,
 		LogMethod:   true,
 		LogError:    true,
+		HandleError: true,
 		Skipper: func(c echo.Context) bool {
 			if len(skip) == 0 {
 				return false

--- a/examples/service.yaml
+++ b/examples/service.yaml
@@ -1,0 +1,21 @@
+name: my service job
+tasks:
+  - name: my service task
+    image: node:14
+    run: |
+      node server.js
+    ports: 
+      - port: 8080
+    files:
+      server.js: |
+        const http = require('http');
+        const hostname = '0.0.0.0';
+        const port = 8080;
+        const server = http.createServer((req, res) => {
+          res.statusCode = 200;
+          res.setHeader('Content-Type', 'text/plain');
+          res.end('Hello World\n');
+        });
+        server.listen(port, hostname, () => {
+          console.log(`Server running at http://${hostname}:${port}/`);
+        });

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ retract v0.1.0
 require (
 	github.com/docker/cli v26.1.1+incompatible
 	github.com/docker/docker v26.1.1+incompatible
+	github.com/docker/go-connections v0.4.0
 	github.com/docker/go-units v0.5.0
 	github.com/expr-lang/expr v1.16.5
 	github.com/fatih/color v1.16.0
@@ -42,7 +43,6 @@ require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
-	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.3 // indirect

--- a/input/task.go
+++ b/input/task.go
@@ -32,6 +32,7 @@ type Task struct {
 	Tags        []string          `json:"tags,omitempty" yaml:"tags,omitempty"`
 	Workdir     string            `json:"workdir,omitempty" yaml:"workdir,omitempty" validate:"max=256"`
 	Priority    int               `json:"priority,omitempty" yaml:"priority,omitempty" validate:"min=0,max=9"`
+	Ports       []Port            `json:"ports,omitempty" yaml:"ports,omitempty" validate:"dive"`
 }
 
 type SubJob struct {
@@ -85,6 +86,10 @@ type AuxTask struct {
 	Registry    *Registry         `json:"registry,omitempty" yaml:"registry,omitempty"`
 	Env         map[string]string `json:"env,omitempty" yaml:"env,omitempty"`
 	Timeout     string            `json:"timeout,omitempty" yaml:"timeout,omitempty"`
+}
+
+type Port struct {
+	Port string `json:"port,omitempty" yaml:"port,omitempty" validate:"required"`
 }
 
 func (m Mount) toMount() tork.Mount {
@@ -164,6 +169,12 @@ func (i Task) toTask() *tork.Task {
 			Password: i.Registry.Password,
 		}
 	}
+	ports := make([]*tork.Port, len(i.Ports))
+	for ix, p := range i.Ports {
+		ports[ix] = &tork.Port{
+			Port: p.Port,
+		}
+	}
 	return &tork.Task{
 		Name:        i.Name,
 		Description: i.Description,
@@ -191,6 +202,7 @@ func (i Task) toTask() *tork.Task {
 		Tags:        i.Tags,
 		Workdir:     i.Workdir,
 		Priority:    i.Priority,
+		Ports:       ports,
 	}
 }
 

--- a/internal/coordinator/api/api.go
+++ b/internal/coordinator/api/api.go
@@ -7,8 +7,11 @@ import (
 	"io"
 	"strconv"
 	"syscall"
+	"time"
 
 	"net/http"
+	"net/http/httputil"
+	"net/url"
 	"strings"
 
 	"github.com/labstack/echo/v4"
@@ -116,6 +119,9 @@ func NewAPI(cfg Config) (*API, error) {
 	if v, ok := cfg.Enabled["tasks"]; !ok || v {
 		r.GET("/tasks/:id", s.getTask)
 		r.GET("/tasks/:id/log", s.getTaskLog)
+		r.Any("/tasks/:id/proxy/:port", s.proxy)
+		r.Any("/tasks/:id/proxy/:port/*", s.proxy)
+		r.PUT("/tasks/:id/complete", s.completeTask)
 	}
 	if v, ok := cfg.Enabled["queues"]; !ok || v {
 		r.GET("/queues", s.listQueues)
@@ -466,6 +472,44 @@ func (s *API) getTask(c echo.Context) error {
 	return c.JSON(http.StatusOK, t)
 }
 
+// Task
+// @Summary Manually complete a running task
+// @Tags tasks
+// @Produce application/json
+// @Success 200 {object} tork.Task
+// @Router /tasks/{id}/complete [put]
+// @Param id path string true "Task ID"
+// @Failure 404 {object} echo.HTTPError
+// @Failure 400 {object} echo.HTTPError
+func (s *API) completeTask(c echo.Context) error {
+	id := c.Param("id")
+	ctx := c.Request().Context()
+	t, err := s.ds.GetTaskByID(c.Request().Context(), id)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusNotFound, err.Error())
+	}
+	if t.State != tork.TaskStateRunning && t.State != tork.TaskStateScheduled {
+		return echo.NewHTTPError(http.StatusBadRequest, "task is not running")
+	}
+	now := time.Now().UTC()
+	t.State = tork.TaskStateCompleted
+	t.CompletedAt = &now
+	if err := s.broker.PublishTask(ctx, mq.QUEUE_COMPLETED, t); err != nil {
+		log.Error().Err(err).Msgf("error publishing service task to completion queue")
+	}
+	// notify the node currently running the task to cancel it
+	node, err := s.ds.GetNodeByID(ctx, t.NodeID)
+	if err != nil {
+		return err
+	}
+	cancelTask := t.Clone()
+	cancelTask.State = tork.TaskStateCancelled
+	if err := s.broker.PublishTask(ctx, node.Queue, cancelTask); err != nil {
+		return err
+	}
+	return c.JSON(http.StatusOK, t)
+}
+
 // getTaskLog
 // @Summary Get a task's log
 // @Tags tasks
@@ -617,6 +661,34 @@ func (s *API) createUser(c echo.Context) error {
 	} else {
 		return c.JSON(http.StatusOK, u)
 	}
+}
+
+func (a *API) proxy(c echo.Context) error {
+	id := c.Param("id")
+	port := c.Param("port")
+	ctx := c.Request().Context()
+	task, err := a.ds.GetTaskByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, datastore.ErrTaskNotFound) {
+			return echo.ErrNotFound
+		}
+		return err
+	}
+	node, err := a.ds.GetNodeByID(ctx, task.NodeID)
+	if err != nil {
+		log.Error().Err(err).Msgf("error looking up node %s", task.NodeID)
+		return echo.ErrServiceUnavailable
+	}
+	backendURL, err := url.Parse(fmt.Sprintf("http://%s:%d", node.Hostname, node.Port))
+	if err != nil {
+		return err
+	}
+	proxy := httputil.NewSingleHostReverseProxy(backendURL)
+	req := c.Request()
+	path := strings.Join(strings.Split(c.Path(), "/")[5:], "/")
+	req.URL.Path = fmt.Sprintf("/tasks/%s/%s/proxy/%s", task.ID, port, path)
+	proxy.ServeHTTP(c.Response(), req)
+	return nil
 }
 
 func (s *API) Start() error {

--- a/internal/coordinator/handlers/started.go
+++ b/internal/coordinator/handlers/started.go
@@ -52,7 +52,7 @@ func (h *startedHandler) handle(ctx context.Context, et task.EventType, t *tork.
 	if j.State == tork.JobStateScheduled {
 		j.State = tork.JobStateRunning
 		if err := h.onJob(ctx, job.StateChange, j); err != nil {
-			return nil
+			return err
 		}
 	}
 	return h.ds.UpdateTask(ctx, t.ID, func(u *tork.Task) error {

--- a/internal/worker/api_test.go
+++ b/internal/worker/api_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/runabol/tork/internal/syncx"
 	"github.com/runabol/tork/mq"
 	"github.com/runabol/tork/runtime/docker"
 	"github.com/stretchr/testify/assert"
@@ -17,7 +18,7 @@ func Test_health(t *testing.T) {
 	api := newAPI(Config{
 		Broker:  mq.NewInMemoryBroker(),
 		Runtime: rt,
-	})
+	}, &syncx.Map[string, runningTask]{})
 	assert.NotNil(t, api)
 	req, err := http.NewRequest("GET", "/health", nil)
 	assert.NoError(t, err)

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -54,6 +54,7 @@ type Limits struct {
 
 type runningTask struct {
 	cancel context.CancelFunc
+	task   *tork.Task
 }
 
 func NewWorker(cfg Config) (*Worker, error) {
@@ -66,6 +67,7 @@ func NewWorker(cfg Config) (*Worker, error) {
 	if cfg.Runtime == nil {
 		return nil, errors.New("must provide runtime")
 	}
+	tasks := new(syncx.Map[string, runningTask])
 	w := &Worker{
 		id:         uuid.NewShortUUID(),
 		name:       cfg.Name,
@@ -73,27 +75,13 @@ func NewWorker(cfg Config) (*Worker, error) {
 		broker:     cfg.Broker,
 		runtime:    cfg.Runtime,
 		queues:     cfg.Queues,
-		tasks:      new(syncx.Map[string, runningTask]),
+		tasks:      tasks,
 		limits:     cfg.Limits,
-		api:        newAPI(cfg),
+		api:        newAPI(cfg, tasks),
 		stop:       make(chan any),
 		middleware: cfg.Middleware,
 	}
 	return w, nil
-}
-
-func (w *Worker) handleTask(t *tork.Task) error {
-	log.Debug().
-		Str("task-id", t.ID).
-		Msg("received task")
-	switch t.State {
-	case tork.TaskStateRunning:
-		return w.runTask(t)
-	case tork.TaskStateCancelled:
-		return w.cancelTask(t)
-	default:
-		return errors.Errorf("invalid task state: %s", t.State)
-	}
 }
 
 func (w *Worker) cancelTask(t *tork.Task) error {
@@ -108,14 +96,25 @@ func (w *Worker) cancelTask(t *tork.Task) error {
 	return nil
 }
 
-func (w *Worker) onTask(t *tork.Task) error {
-	t.State = tork.TaskStateRunning
+func (w *Worker) handleTask(t *tork.Task) error {
 	started := time.Now().UTC()
 	t.StartedAt = &started
-	t.State = tork.TaskStateRunning
 	t.NodeID = w.id
+	// prepare limits
+	if t.Limits == nil && (w.limits.DefaultCPUsLimit != "" || w.limits.DefaultMemoryLimit != "") {
+		t.Limits = &tork.TaskLimits{}
+	}
+	if t.Limits != nil && t.Limits.CPUs == "" {
+		t.Limits.CPUs = w.limits.DefaultCPUsLimit
+	}
+	if t.Limits != nil && t.Limits.Memory == "" {
+		t.Limits.Memory = w.limits.DefaultMemoryLimit
+	}
+	if t.Timeout == "" {
+		t.Timeout = w.limits.DefaultTimeout
+	}
 	adapter := func(ctx context.Context, et task.EventType, t *tork.Task) error {
-		return w.handleTask(t)
+		return w.runTask(t)
 	}
 	mw := task.ApplyMiddleware(adapter, w.middleware)
 	if err := mw(context.Background(), task.StateChange, t); err != nil {
@@ -129,10 +128,75 @@ func (w *Worker) onTask(t *tork.Task) error {
 }
 
 func (w *Worker) runTask(t *tork.Task) error {
+	if t.Ports != nil {
+		return w.runServiceTask(t)
+	}
+	return w.runPrcessingTask(t)
+}
+
+func (w *Worker) runServiceTask(t *tork.Task) error {
+	atomic.AddInt32(&w.taskCount, 1)
+	// clone the task so that the runtime
+	// process can mutate the task without
+	// affecting the original
+	rt := t.Clone()
+	// create a cancellation context in case
+	// the coordinator wants to cancel the
+	// task later on
+	ctx, cancel := context.WithCancel(context.Background())
+	w.tasks.Set(t.ID, runningTask{
+		cancel: cancel,
+		task:   rt,
+	})
+	// run the task
+	go func() {
+		defer func() {
+			atomic.AddInt32(&w.taskCount, -1)
+		}()
+		defer cancel()
+		defer w.tasks.Delete(t.ID)
+		// let the coordinator know that the task started executing
+		if err := w.broker.PublishTask(ctx, mq.QUEUE_STARTED, t); err != nil {
+			log.Error().Err(err).Msgf("error publishing service task to started queue")
+		}
+		// actually run the task
+		if err := w.doRunTask(ctx, rt); err != nil {
+			finished := time.Now().UTC()
+			t.FailedAt = &finished
+			t.State = tork.TaskStateFailed
+			t.Error = err.Error()
+		}
+		switch rt.State {
+		case tork.TaskStateCompleted:
+			t.Result = rt.Result
+			t.CompletedAt = rt.CompletedAt
+			t.State = rt.State
+			if err := w.broker.PublishTask(ctx, mq.QUEUE_COMPLETED, t); err != nil {
+				log.Error().Err(err).Msgf("error publishing service task to completion queue")
+			}
+		case tork.TaskStateFailed:
+			t.Error = rt.Error
+			t.FailedAt = rt.FailedAt
+			t.State = rt.State
+			if err := w.broker.PublishTask(ctx, mq.QUEUE_ERROR, t); err != nil {
+				log.Error().Err(err).Msgf("error publishing service task to error queue")
+			}
+		default:
+			log.Error().Msgf("unexpected state %s for task %s", rt.State, t.ID)
+		}
+	}()
+	return nil
+}
+
+func (w *Worker) runPrcessingTask(t *tork.Task) error {
 	atomic.AddInt32(&w.taskCount, 1)
 	defer func() {
 		atomic.AddInt32(&w.taskCount, -1)
 	}()
+	// clone the task so that the downstream
+	// process can mutate the task without
+	// affecting the original
+	rt := t.Clone()
 	// create a cancellation context in case
 	// the coordinator wants to cancel the
 	// task later on
@@ -140,16 +204,13 @@ func (w *Worker) runTask(t *tork.Task) error {
 	defer cancel()
 	w.tasks.Set(t.ID, runningTask{
 		cancel: cancel,
+		task:   rt,
 	})
 	defer w.tasks.Delete(t.ID)
 	// let the coordinator know that the task started executing
 	if err := w.broker.PublishTask(ctx, mq.QUEUE_STARTED, t); err != nil {
 		return err
 	}
-	// clone the task so that the downstream
-	// process can mutate the task without
-	// affecting the original
-	rt := t.Clone()
 	if err := w.doRunTask(ctx, rt); err != nil {
 		return err
 	}
@@ -175,19 +236,6 @@ func (w *Worker) runTask(t *tork.Task) error {
 }
 
 func (w *Worker) doRunTask(ctx context.Context, t *tork.Task) error {
-	// prepare limits
-	if t.Limits == nil && (w.limits.DefaultCPUsLimit != "" || w.limits.DefaultMemoryLimit != "") {
-		t.Limits = &tork.TaskLimits{}
-	}
-	if t.Limits != nil && t.Limits.CPUs == "" {
-		t.Limits.CPUs = w.limits.DefaultCPUsLimit
-	}
-	if t.Limits != nil && t.Limits.Memory == "" {
-		t.Limits.Memory = w.limits.DefaultMemoryLimit
-	}
-	if t.Timeout == "" {
-		t.Timeout = w.limits.DefaultTimeout
-	}
 	// create timeout context -- if timeout is defined
 	rctx := ctx
 	if t.Timeout != "" {
@@ -200,8 +248,7 @@ func (w *Worker) doRunTask(ctx context.Context, t *tork.Task) error {
 		rctx = tctx
 	}
 	// run the task
-	rtTask := t.Clone()
-	if err := w.runtime.Run(rctx, rtTask); err != nil {
+	if err := w.runtime.Run(rctx, t); err != nil {
 		finished := time.Now().UTC()
 		t.FailedAt = &finished
 		t.State = tork.TaskStateFailed
@@ -211,7 +258,6 @@ func (w *Worker) doRunTask(ctx context.Context, t *tork.Task) error {
 	finished := time.Now().UTC()
 	t.CompletedAt = &finished
 	t.State = tork.TaskStateCompleted
-	t.Result = rtTask.Result
 	return nil
 }
 
@@ -240,6 +286,7 @@ func (w *Worker) sendHeartbeats() {
 				Status:          status,
 				LastHeartbeatAt: time.Now().UTC(),
 				Hostname:        hostname,
+				Port:            w.api.port,
 				TaskCount:       int(atomic.LoadInt32(&w.taskCount)),
 				Version:         tork.Version,
 			},
@@ -263,7 +310,7 @@ func (w *Worker) Start() error {
 		return err
 	}
 	// subscribe for a private queue for the node
-	if err := w.broker.SubscribeForTasks(fmt.Sprintf("%s%s", mq.QUEUE_EXCLUSIVE_PREFIX, w.id), w.handleTask); err != nil {
+	if err := w.broker.SubscribeForTasks(fmt.Sprintf("%s%s", mq.QUEUE_EXCLUSIVE_PREFIX, w.id), w.cancelTask); err != nil {
 		return errors.Wrapf(err, "error subscribing for queue: %s", w.id)
 	}
 	// subscribe to shared work queues
@@ -272,7 +319,7 @@ func (w *Worker) Start() error {
 			continue
 		}
 		for i := 0; i < concurrency; i++ {
-			err := w.broker.SubscribeForTasks(qname, w.onTask)
+			err := w.broker.SubscribeForTasks(qname, w.handleTask)
 			if err != nil {
 				return errors.Wrapf(err, "error subscribing for queue: %s", qname)
 			}

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -207,7 +207,7 @@ func Test_handleTaskCancel(t *testing.T) {
 
 	// cancel the task immediately upon start
 	err = b.SubscribeForTasks(mq.QUEUE_STARTED, func(tk *tork.Task) error {
-		err := w.handleTask(&tork.Task{
+		err := w.cancelTask(&tork.Task{
 			ID:    tid,
 			State: tork.TaskStateCancelled,
 		})
@@ -530,4 +530,56 @@ func Test_handleTaskRunDefaultLimitOK(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, "/somevolume", t1.Mounts[0].Target)
+}
+
+func Test_runServiceTask(t *testing.T) {
+	rt, err := docker.NewDockerRuntime()
+	assert.NoError(t, err)
+
+	b := mq.NewInMemoryBroker()
+
+	w, err := NewWorker(Config{
+		Broker:  b,
+		Runtime: rt,
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, w)
+
+	starts := make(chan any)
+	err = b.SubscribeForTasks(mq.QUEUE_STARTED, func(tk *tork.Task) error {
+		assert.Equal(t, int32(1), atomic.LoadInt32(&w.taskCount))
+		close(starts)
+		return nil
+	})
+	assert.NoError(t, err)
+
+	t1 := &tork.Task{
+		ID:    uuid.NewUUID(),
+		Image: "node:lts-alpine3.20",
+		Run:   "node server.js",
+		Ports: []*tork.Port{{
+			Port: "8080",
+		}},
+		Files: map[string]string{
+			"server.js": `
+             const http = require('http');
+             const hostname = '0.0.0.0';
+             const port = 8080;
+             const server = http.createServer((req, res) => {
+               res.statusCode = 200;
+               res.setHeader('Content-Type', 'text/plain');
+               res.end('Hello World\n');
+             });
+            server.listen(port, hostname, () => {
+              console.log('server running');
+            });
+			`,
+		},
+	}
+
+	err = w.handleTask(t1)
+	assert.NoError(t, err)
+	<-starts
+	err = w.cancelTask(t1)
+	assert.NoError(t, err)
 }

--- a/node.go
+++ b/node.go
@@ -24,6 +24,7 @@ type Node struct {
 	Queue           string     `json:"queue,omitempty"`
 	Status          NodeStatus `json:"status,omitempty"`
 	Hostname        string     `json:"hostname,omitempty"`
+	Port            int        `json:"port,omitempty"`
 	TaskCount       int        `json:"taskCount,omitempty"`
 	Version         string     `json:"version"`
 }
@@ -38,6 +39,7 @@ func (n *Node) Clone() *Node {
 		Queue:           n.Queue,
 		Status:          n.Status,
 		Hostname:        n.Hostname,
+		Port:            n.Port,
 		TaskCount:       n.TaskCount,
 		Version:         n.Version,
 	}

--- a/task.go
+++ b/task.go
@@ -64,6 +64,7 @@ type Task struct {
 	Workdir     string            `json:"workdir,omitempty"`
 	Priority    int               `json:"priority,omitempty"`
 	Progress    float64           `json:"progress,omitempty"`
+	Ports       []*Port           `json:"ports,omitempty"`
 	Internal    bool              `json:"-"`
 }
 
@@ -129,6 +130,11 @@ type TaskLimits struct {
 type Registry struct {
 	Username string `json:"username,omitempty"`
 	Password string `json:"password,omitempty"`
+}
+
+type Port struct {
+	Port    string `json:"port,omitempty"`
+	Address string `json:"-"`
 }
 
 func (s TaskState) IsActive() bool {
@@ -203,6 +209,7 @@ func (t *Task) Clone() *Task {
 		Workdir:     t.Workdir,
 		Priority:    t.Priority,
 		Progress:    t.Progress,
+		Ports:       ClonePorts(t.Ports),
 	}
 }
 
@@ -283,4 +290,27 @@ func NewTaskSummary(t *Task) *TaskSummary {
 		Var:         t.Var,
 		Tags:        t.Tags,
 	}
+}
+
+func (p *Port) Clone() *Port {
+	return &Port{
+		Port: p.Port,
+	}
+}
+
+func ClonePorts(ports []*Port) []*Port {
+	copy := make([]*Port, len(ports))
+	for i, v := range ports {
+		copy[i] = v.Clone()
+	}
+	return copy
+}
+
+func (t *Task) Port(name string) (*Port, bool) {
+	for _, p := range t.Ports {
+		if p.Port == name {
+			return p, true
+		}
+	}
+	return nil, false
 }


### PR DESCRIPTION
This PR adds support for long-running or service tasks:

Potential use-cases:

1. Long-running tasks that retain their state over time. 
2. Running temporary APIs.

Example:

1. Create a job containing a task with a `ports` block.

```yaml
# examples/service.yaml
name: my service job
tasks:
  - name: my service task
    image: node:14
    run: |
      node server.js
    ports: 
      - port: 8080
    files:
      server.js: |
        const http = require('http');
        const hostname = '0.0.0.0';
        const port = 8080;
        const server = http.createServer((req, res) => {
          res.statusCode = 200;
          res.setHeader('Content-Type', 'text/plain');
          res.end('Hello World\n');
        });
        server.listen(port, hostname, () => {
          console.log(`Server running at http://${hostname}:${port}/`);
        });
```
```bash
JOB_ID=$(curl -s -X POST \
  --data-binary @examples/service.yaml \
  -H "Content-type: text/yaml" http://localhost:8000/jobs | jq -r .id)
```
4. Get the task id
```bash
TASK_ID=$(curl -s http://localhost:8000/jobs/$JOB_ID | jq -r '.execution[0].id')
```
5. Once the task is `RUNNING`, Route requests to the task container:
```bash
curl -s http://localhost:8000/tasks/$TASK_ID/proxy/8080/some/path
Hello World
```

6. Mark the task as `COMPLETED`

```bash
curl -s -X PUT http://localhost:8000/tasks/$TASK_ID/complete | jq .
```