### PR TITLE
Each concurrency control

### DIFF
--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -28,6 +28,7 @@ type Datastore interface {
 	UpdateTask(ctx context.Context, id string, modify func(u *tork.Task) error) error
 	GetTaskByID(ctx context.Context, id string) (*tork.Task, error)
 	GetActiveTasks(ctx context.Context, jobID string) ([]*tork.Task, error)
+	GetNextTask(ctx context.Context, parentTaskID string) (*tork.Task, error)
 	CreateTaskLogPart(ctx context.Context, p *tork.TaskLogPart) error
 	GetTaskLogParts(ctx context.Context, taskID string, page, size int) (*Page[*tork.TaskLogPart], error)
 

--- a/datastore/inmemory/inmemory.go
+++ b/datastore/inmemory/inmemory.go
@@ -260,6 +260,16 @@ func (ds *InMemoryDatastore) GetActiveTasks(ctx context.Context, jobID string) (
 	return result, nil
 }
 
+func (ds *InMemoryDatastore) GetNextTask(ctx context.Context, parentTaskID string) (*tork.Task, error) {
+	result := ds.tasks.List(func(v *tork.Task) bool {
+		return v.ParentID == parentTaskID && v.State == tork.TaskStateCreated
+	})
+	if len(result) == 0 {
+		return nil, datastore.ErrTaskNotFound
+	}
+	return result[0], nil
+}
+
 func (ds *InMemoryDatastore) GetJobs(ctx context.Context, currentUser, q string, page, size int) (*datastore.Page[*tork.JobSummary], error) {
 	parseQuery := func(query string) (string, []string) {
 		terms := []string{}

--- a/input/task.go
+++ b/input/task.go
@@ -47,9 +47,10 @@ type SubJob struct {
 }
 
 type Each struct {
-	Var  string `json:"var,omitempty" yaml:"var,omitempty" `
-	List string `json:"list,omitempty" yaml:"list,omitempty" validate:"required,expr"`
-	Task Task   `json:"task,omitempty" yaml:"task,omitempty" validate:"required"`
+	Var         string `json:"var,omitempty" yaml:"var,omitempty" `
+	List        string `json:"list,omitempty" yaml:"list,omitempty" validate:"required,expr"`
+	Task        Task   `json:"task,omitempty" yaml:"task,omitempty" validate:"required"`
+	Concurrency int    `json:"concurrency,omitempty" yaml:"concurrency,omitempty" validate:"min=0,max=99999"`
 }
 
 type Parallel struct {
@@ -135,9 +136,10 @@ func (i Task) toTask() *tork.Task {
 	var each *tork.EachTask
 	if i.Each != nil {
 		each = &tork.EachTask{
-			Var:  i.Each.Var,
-			List: i.Each.List,
-			Task: i.Each.Task.toTask(),
+			Var:         i.Each.Var,
+			List:        i.Each.List,
+			Task:        i.Each.Task.toTask(),
+			Concurrency: i.Each.Concurrency,
 		}
 	}
 	var subjob *tork.SubJobTask

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -217,6 +217,22 @@ func (c *Cache[V]) allItems() map[string]*Item[V] {
 	return m
 }
 
+func (c *Cache[V]) List(filters ...func(v V) bool) (vals []V) {
+	items := c.allItems()
+next:
+	for _, v := range items {
+		for _, filter := range filters {
+			if !filter(v.Object) {
+				continue next
+			}
+		}
+		v.mu.Lock()
+		vals = append(vals, v.Object)
+		v.mu.Unlock()
+	}
+	return
+}
+
 func (c *Cache[V]) Iterate(it func(key string, v V)) {
 	items := c.allItems()
 	for k, v := range items {

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -593,3 +593,25 @@ func BenchmarkDeleteExpiredLoop(b *testing.B) {
 		tc.deleteExpired()
 	}
 }
+
+func TestList(t *testing.T) {
+	tc := New[*tork.Task](DefaultExpiration, 0)
+
+	for i := 0; i < 1000; i++ {
+		tc.SetWithExpiration(fmt.Sprintf("foo%d", i), &tork.Task{Name: "some task"}, DefaultExpiration)
+	}
+
+	r := sync.WaitGroup{}
+	r.Add(100)
+
+	for i := 0; i < 100; i++ {
+		go func() {
+			defer r.Done()
+			tc.List(func(v *tork.Task) bool {
+				return false
+			})
+		}()
+	}
+
+	r.Wait()
+}

--- a/internal/slices/slices.go
+++ b/internal/slices/slices.go
@@ -15,3 +15,11 @@ func Intersect[T comparable](a []T, b []T) bool {
 
 	return false
 }
+
+func Map[T any, U any](items []T, f func(T) U) []U {
+	result := make([]U, len(items))
+	for i, v := range items {
+		result[i] = f(v)
+	}
+	return result
+}

--- a/internal/slices/slirces_test.go
+++ b/internal/slices/slirces_test.go
@@ -3,6 +3,7 @@ package slices
 import (
 	"testing"
 
+	"github.com/runabol/tork"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -24,4 +25,19 @@ func TestHasIntersection(t *testing.T) {
 		got := Intersect(tt.slice1, tt.slice2)
 		assert.Equal(t, tt.want, got)
 	}
+}
+
+func TestMap(t *testing.T) {
+	tests := []*tork.Task{{
+		Name: "a",
+	}, {
+		Name: "b",
+	}, {
+		Name: "c",
+	}}
+
+	got := Map(tests, func(tk *tork.Task) string {
+		return tk.Name
+	})
+	assert.Equal(t, []string{"a", "b", "c"}, got)
 }

--- a/task.go
+++ b/task.go
@@ -12,6 +12,7 @@ import (
 type TaskState string
 
 const (
+	TaskStateCreated   TaskState = "CREATED"
 	TaskStatePending   TaskState = "PENDING"
 	TaskStateScheduled TaskState = "SCHEDULED"
 	TaskStateRunning   TaskState = "RUNNING"
@@ -21,6 +22,13 @@ const (
 	TaskStateFailed    TaskState = "FAILED"
 	TaskStateSkipped   TaskState = "SKIPPED"
 )
+
+var TaskStateActive = []TaskState{
+	TaskStateCreated,
+	TaskStatePending,
+	TaskStateScheduled,
+	TaskStateRunning,
+}
 
 // Task is the basic unit of work that a Worker can handle.
 type Task struct {
@@ -115,6 +123,8 @@ type EachTask struct {
 	Task        *Task  `json:"task,omitempty"`
 	Size        int    `json:"size,omitempty"`
 	Completions int    `json:"completions,omitempty"`
+	Concurrency int    `json:"concurrency,omitempty"`
+	Index       int    `json:"index,omitempty"`
 }
 
 type TaskRetry struct {
@@ -138,9 +148,7 @@ type Port struct {
 }
 
 func (s TaskState) IsActive() bool {
-	return s == TaskStatePending ||
-		s == TaskStateScheduled ||
-		s == TaskStateRunning
+	return slices.Contains(TaskStateActive, s)
 }
 
 func (t *Task) Clone() *Task {
@@ -242,6 +250,8 @@ func (e *EachTask) Clone() *EachTask {
 		Task:        e.Task.Clone(),
 		Size:        e.Size,
 		Completions: e.Completions,
+		Concurrency: e.Concurrency,
+		Index:       e.Index,
 	}
 }
 

--- a/task_test.go
+++ b/task_test.go
@@ -37,3 +37,26 @@ func TestCloneTask(t *testing.T) {
 	assert.NotEqual(t, t1.Limits.CPUs, t2.Limits.CPUs)
 	assert.NotEqual(t, t1.Parallel.Tasks[0].Env, t2.Parallel.Tasks[0].Env)
 }
+
+func TestIsActive(t *testing.T) {
+	t1 := &tork.Task{
+		State: tork.TaskStateCancelled,
+	}
+	assert.False(t, t1.State.IsActive())
+	t2 := &tork.Task{
+		State: tork.TaskStateCreated,
+	}
+	assert.True(t, t2.State.IsActive())
+	t3 := &tork.Task{
+		State: tork.TaskStatePending,
+	}
+	assert.True(t, t3.State.IsActive())
+	t4 := &tork.Task{
+		State: tork.TaskStateRunning,
+	}
+	assert.True(t, t4.State.IsActive())
+	t5 := &tork.Task{
+		State: tork.TaskStateCompleted,
+	}
+	assert.False(t, t5.State.IsActive())
+}


### PR DESCRIPTION
Adds support for concurrency control on `each` tasks. 

By default [each tasks](https://www.tork.run/tasks#each-task) publish their sub-tasks to work queues all at once.

For each tasks with a large `list` this could result in saturating the cluster with many small tasks -- potentially "starving" other jobs.

This PR adds concurrency control, such that the job author can control the maximum number of each tasks that can execute at any given moment, across the entire cluster. Example:


```yaml
name: my job
tasks:
  - name: sample each task
    each:
      list: "{{ sequence(1,5) }}"
      concurrency: 1
      task:
        name: output task item
        run: |
          sleep $ITEM
          echo -n "slept $ITEM seconds" > $TORK_OUTPUT
        image: ubuntu:mantic
        env:
          ITEM: "{{item.value}}"
```


In this example, only 1 `each` task will execute at any given moment.