### PR TITLE
Feature: host port for service tasks

### DIFF
--- a/internal/worker/api.go
+++ b/internal/worker/api.go
@@ -76,7 +76,7 @@ func (s *api) proxy(c echo.Context) error {
 	if !ok {
 		return echo.NewHTTPError(http.StatusNotFound, "port not found")
 	}
-	backendURL, err := url.Parse(fmt.Sprintf("http://localhost:%d", binding.HostPort))
+	backendURL, err := url.Parse(fmt.Sprintf("http://localhost:%s", binding.HostPort))
 	if err != nil {
 		return err
 	}

--- a/internal/worker/api_test.go
+++ b/internal/worker/api_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"strconv"
 	"testing"
 
 	"github.com/runabol/tork"
@@ -46,7 +45,7 @@ func Test_proxyTaskRoot(t *testing.T) {
 	svrURL, err := url.Parse(svr.URL)
 	assert.NoError(t, err)
 
-	port, err := strconv.Atoi(svrURL.Port())
+	port := svrURL.Port()
 	assert.NoError(t, err)
 
 	tasks := &syncx.Map[string, runningTask]{}
@@ -84,7 +83,7 @@ func Test_proxyTaskSomePath(t *testing.T) {
 	svrURL, err := url.Parse(svr.URL)
 	assert.NoError(t, err)
 
-	port, err := strconv.Atoi(svrURL.Port())
+	port := svrURL.Port()
 	assert.NoError(t, err)
 
 	tasks := &syncx.Map[string, runningTask]{}

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -284,7 +284,7 @@ func (d *DockerRuntime) doRun(ctx context.Context, t *tork.Task, logger io.Write
 		exposedPorts[nat.Port(p.Port)] = struct{}{}
 		portBindings[nat.Port(p.Port)] = []nat.PortBinding{{
 			HostIP:   "localhost",
-			HostPort: fmt.Sprintf("%d/tcp", p.HostPort),
+			HostPort: fmt.Sprintf("%s/tcp", p.HostPort),
 		}}
 	}
 

--- a/runtime/docker/docker_test.go
+++ b/runtime/docker/docker_test.go
@@ -729,7 +729,7 @@ func TestRunServiceTask(t *testing.T) {
 		Run:   "node server.js",
 		Ports: []*tork.Port{{
 			Port:     "8080",
-			HostPort: 55000,
+			HostPort: "55000",
 		}},
 		Files: map[string]string{
 			"server.js": `

--- a/task.go
+++ b/task.go
@@ -147,7 +147,7 @@ type Registry struct {
 
 type Port struct {
 	Port     string `json:"port,omitempty"`
-	HostPort int    `json:"-"`
+	HostPort string `json:"-"`
 }
 
 func (s TaskState) IsActive() bool {


### PR DESCRIPTION
This PR build on PR https://github.com/runabol/tork/pull/433 and adds support for user-defined host port on service tasks. 

Example:

```yaml
name: my service job
tasks:
  - name: my service task
    image: node:14
    run: |
      node server.js
    ports: 
      - port: 9090:8080 # host-port:container-port
    files:
      server.js: |
        const http = require('http');
        const hostname = '0.0.0.0';
        const port = 8080;
        const server = http.createServer((req, res) => {
          res.statusCode = 200;
          res.setHeader('Content-Type', 'text/plain');
          res.end('Hello World\n');
        });
        server.listen(port, hostname, () => {
          console.log(`Server running at http://${hostname}:${port}/`);
        });
```
