### PR TITLE
Feature: body limit middleware

### DIFF
--- a/configs/sample.config.toml
+++ b/configs/sample.config.toml
@@ -61,6 +61,9 @@ enabled = false
 enabled = false
 key = ""        # if left blank, it will auto-generate a key and print it to the logs on startup
 
+[middleware.web]
+bodylimit = 64K # Limit can be specified as 4x, where x is one of the multiple from K, M, G, T or P.
+
 
 # rate limiter middleware
 [middleware.web.ratelimit]

--- a/engine/coordinator.go
+++ b/engine/coordinator.go
@@ -102,6 +102,10 @@ func echoMiddleware(ds datastore.Datastore) []echo.MiddlewareFunc {
 		mw = append(mw, rateLimit(rps))
 	}
 
+	// body limit
+	bodyLimit := conf.StringDefault("middleware.web.bodylimit", "64K")
+	mw = append(mw, middleware.BodyLimit(bodyLimit))
+
 	loggerEnabled := conf.BoolDefault("middleware.web.logger.enabled", true)
 	if loggerEnabled {
 		mw = append(mw, logger())


### PR DESCRIPTION
Body limit middleware sets the maximum allowed size for a request body, if the size exceeds the configured limit (default is `64K`, it sends `413 - Request Entity Too Large` response. The body limit is determined based on both `Content-Length` request header and actual content read, which makes it super secure.

Limit can be specified as `4x`, where x is one of the multiple from K, M, G, T or P.

Example:

```
TORK_MIDDLEWARE_WEB_BODYLIMIT=1M
```