### PR TITLE
Feature: make busybox image name configurable

### DIFF
--- a/configs/sample.config.toml
+++ b/configs/sample.config.toml
@@ -117,3 +117,4 @@ gid = ""             # set the gid for the the task process (recommended)
 [runtime.docker]
 config = ""
 sandbox = false
+busybox.image = "busybox:stable"

--- a/engine/worker.go
+++ b/engine/worker.go
@@ -76,6 +76,7 @@ func (e *Engine) initRuntime() (runtime.Runtime, error) {
 			docker.WithConfig(conf.String("runtime.docker.config")),
 			docker.WithBroker(e.broker),
 			docker.WithSandbox(conf.BoolDefault("runtime.docker.sandbox", false)),
+			docker.WithBusyboxImage(conf.StringDefault("runtime.docker.busybox.image", "busybox:stable")),
 		)
 	case runtime.Shell:
 		return shell.NewShellRuntime(shell.Config{


### PR DESCRIPTION
This PR adds the ability to configure a custom `busybox` image name when using [sandbox mode](https://www.tork.run/runtime#sandbox-mode-experimental).

Example:

```
TORK_RUNTIME_DOCKER_BUSYBOX_IMAGE=myprivateregistry.com/busybox:stable
```