### PR TITLE
Feature: job retention duration

### DIFF
--- a/configs/sample.config.toml
+++ b/configs/sample.config.toml
@@ -20,9 +20,12 @@ durable.queues = false
 [datastore]
 type = "inmemory" # inmemory | postgres
 
+[datastore.retention]
+logs.duration = "168h" # 1 week
+jobs.duration = "8760h" # 1 year
+
 [datastore.postgres]
 dsn = "host=localhost user=tork password=tork dbname=tork port=5432 sslmode=disable"
-task.logs.interval = "168h"
 
 [coordinator]
 address = "localhost:8000"

--- a/engine/datastore.go
+++ b/engine/datastore.go
@@ -37,7 +37,8 @@ func (e *Engine) createDatastore(dstype string) (datastore.Datastore, error) {
 			"host=localhost user=tork password=tork dbname=tork port=5432 sslmode=disable",
 		)
 		return postgres.NewPostgresDataStore(dsn,
-			postgres.WithTaskLogRetentionPeriod(conf.DurationDefault("datastore.postgres.task.logs.interval", postgres.DefaultTaskLogsRetentionPeriod)),
+			postgres.WithLogsRetentionDuration(conf.DurationDefault("datastore.retention.logs.duration", postgres.DefaultLogsRetentionDuration)),
+			postgres.WithJobsRetentionDuration(conf.DurationDefault("datastore.retention.jobs.duration", postgres.DefaultJobsRetentionDuration)),
 		)
 	default:
 		return nil, errors.Errorf("unknown datastore type: %s", dstype)


### PR DESCRIPTION
This PR:

1. Adds support for automatic expiry and deletion of jobs from the datastore after a configurable amount of time (default is 1 year). 

2. Renames the `datastore.postgres.task.logs.interval` config to `datastore.retention.logs.duration`.