### PR TITLE
Feature: job wait

### DIFF
--- a/input/job.go
+++ b/input/job.go
@@ -21,6 +21,11 @@ type Job struct {
 	Webhooks    []Webhook         `json:"webhooks,omitempty" yaml:"webhooks,omitempty" validate:"dive"`
 	Permissions []Permission      `json:"permissions,omitempty" yaml:"permissions,omitempty" validate:"dive"`
 	AutoDelete  *AutoDelete       `json:"autoDelete,omitempty" yaml:"autoDelete,omitempty"`
+	Wait        *Wait             `json:"wait,omitempty" yaml:"wait,omitempty"`
+}
+
+type Wait struct {
+	Timeout string `json:"timeout,omitempty" yaml:"timeout,omitempty" validate:"duration,required"`
 }
 
 type ScheduledJob struct {

--- a/internal/coordinator/api/api_test.go
+++ b/internal/coordinator/api/api_test.go
@@ -896,3 +896,27 @@ func TestShutdown(t *testing.T) {
 	w := httptest.NewRecorder()
 	api.server.Handler.ServeHTTP(w, req)
 }
+
+func Test_createJobAndWait(t *testing.T) {
+	api, err := NewAPI(Config{
+		DataStore: inmemory.NewInMemoryDatastore(),
+		Broker:    broker.NewInMemoryBroker(),
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, api)
+	req, err := http.NewRequest("POST", "/jobs", strings.NewReader(`{
+		"name":"test job",
+		"wait": {
+			"timeout": "1s"
+		},
+		"tasks":[{
+			"name":"test task",
+			"image":"some:image"
+		}]
+	}`))
+	req.Header.Add("Content-Type", "application/json")
+	assert.NoError(t, err)
+	w := httptest.NewRecorder()
+	api.server.Handler.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusRequestTimeout, w.Code)
+}


### PR DESCRIPTION
This PR introduces a new feature  that allows users to optionally `wait` on a job to terminate upon submission.

When used the `POST /jobs` endpoint will block until the job arrived at a terminal state (`COMPLETED`, `FAILED`, `CANCELLED`) or after the defined timeout.

Example:

```yaml
name: hello world
wait:
  timeout: "5s" # required
output: "{{ tasks.hello }}"
tasks:
  - var: hello
    name: simple task
    image: ubuntu:mantic
    run: echo -n hello world > $TORK_OUTPUT
```

