### PR TITLE
Feature: privileged execution

### DIFF
--- a/configs/sample.config.toml
+++ b/configs/sample.config.toml
@@ -119,5 +119,7 @@ gid = ""             # set the gid for the the task process (recommended)
 
 [runtime.docker]
 config = ""
+privileged = false # run containers in privileged mode (not recommended)
 
 [runtime.podman]
+privileged = false # run containers in privileged mode (not recommended)

--- a/engine/worker.go
+++ b/engine/worker.go
@@ -76,6 +76,7 @@ func (e *Engine) initRuntime() (runtime.Runtime, error) {
 			docker.WithMounter(mounter),
 			docker.WithConfig(conf.String("runtime.docker.config")),
 			docker.WithBroker(e.brokerRef),
+			docker.WithPrivileged(conf.Bool("runtime.docker.privileged")),
 		)
 	case runtime.Shell:
 		return shell.NewShellRuntime(shell.Config{
@@ -99,6 +100,7 @@ func (e *Engine) initRuntime() (runtime.Runtime, error) {
 		return podman.NewPodmanRuntime(
 			podman.WithBroker(e.brokerRef),
 			podman.WithMounter(mounter),
+			podman.WithPrivileged(conf.Bool("runtime.podman.privileged")),
 		), nil
 	default:
 		return nil, errors.Errorf("unknown runtime type: %s", runtimeType)

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -41,13 +41,14 @@ const (
 )
 
 type DockerRuntime struct {
-	client  *client.Client
-	tasks   *syncx.Map[string, string]
-	images  *syncx.Map[string, bool]
-	pullq   chan *pullRequest
-	mounter runtime.Mounter
-	broker  broker.Broker
-	config  string
+	client     *client.Client
+	tasks      *syncx.Map[string, string]
+	images     *syncx.Map[string, bool]
+	pullq      chan *pullRequest
+	mounter    runtime.Mounter
+	broker     broker.Broker
+	config     string
+	privileged bool
 }
 
 type dockerLogsReader struct {
@@ -78,6 +79,12 @@ func WithMounter(mounter runtime.Mounter) Option {
 func WithBroker(broker broker.Broker) Option {
 	return func(rt *DockerRuntime) {
 		rt.broker = broker
+	}
+}
+
+func WithPrivileged(privileged bool) Option {
+	return func(rt *DockerRuntime) {
+		rt.privileged = privileged
 	}
 }
 
@@ -260,6 +267,7 @@ func (d *DockerRuntime) doRun(ctx context.Context, t *tork.Task, logger io.Write
 		PublishAllPorts: false,
 		Mounts:          mounts,
 		Resources:       resources,
+		Privileged:      d.privileged,
 	}
 
 	cmd := t.CMD

--- a/runtime/docker/docker_test.go
+++ b/runtime/docker/docker_test.go
@@ -559,3 +559,35 @@ func Test_imagePullPrivateRegistry(t *testing.T) {
 
 	assert.NoError(t, err)
 }
+
+func TestRunTaskWithPrivilegedModeOn(t *testing.T) {
+	rt, err := NewDockerRuntime(WithPrivileged(true))
+	assert.NoError(t, err)
+	assert.NotNil(t, rt)
+
+	ctx := context.Background()
+	t1 := &tork.Task{
+		ID:    uuid.NewUUID(),
+		Image: "alpine:3.18.3",
+		Run:   "RESULT=$(sysctl -w net.ipv4.ip_forward=1 > /dev/null 2>&1 && echo 'Can modify kernel params' || echo 'Cannot modify kernel params'); echo $RESULT > $TORK_OUTPUT",
+	}
+	err = rt.Run(ctx, t1)
+	assert.NoError(t, err)
+	assert.Equal(t, "Can modify kernel params\n", t1.Result)
+}
+
+func TestRunTaskWithPrivilegedModeOff(t *testing.T) {
+	rt, err := NewDockerRuntime(WithPrivileged(false))
+	assert.NoError(t, err)
+	assert.NotNil(t, rt)
+
+	ctx := context.Background()
+	t1 := &tork.Task{
+		ID:    uuid.NewUUID(),
+		Image: "alpine:3.18.3",
+		Run:   "RESULT=$(sysctl -w net.ipv4.ip_forward=1 > /dev/null 2>&1 && echo 'Can modify kernel params' || echo 'Cannot modify kernel params'); echo $RESULT > $TORK_OUTPUT",
+	}
+	err = rt.Run(ctx, t1)
+	assert.NoError(t, err)
+	assert.Equal(t, "Cannot modify kernel params\n", t1.Result)
+}


### PR DESCRIPTION
This pull request introduces a new feature to Tork, enabling users to configure workers to execute container tasks in [privileged mode](https://docs.docker.com/engine/containers/run/#runtime-privilege-and-linux-capabilities). The feature is opt-in and can be enabled by setting the appropriate environment variable based on the runtime in use:

* For Docker: Set `TORK_RUNTIME_DOCKER_PRIVILEGED=true`
* For Podman: Set `TORK_RUNTIME_PODMAN_PRIVILEGED=true`

When enabled, the worker will run container tasks with elevated privileges, allowing access to additional system resources and capabilities as defined by the respective runtime. This is particularly useful for workflows requiring privileged operations, such as interacting with host devices or performing system-level tasks.