### PR TITLE
Feature: sidecar probe

### DIFF
--- a/datastore/postgres/postgres_test.go
+++ b/datastore/postgres/postgres_test.go
@@ -1509,6 +1509,7 @@ func TestPostgresGetActiveScheduledJobs(t *testing.T) {
 	sj1 := &tork.ScheduledJob{
 		ID:        uuid.NewUUID(),
 		Name:      "Scheduled Job 1",
+		Cron:      "* * * * *",
 		CreatedAt: now,
 		CreatedBy: u,
 		State:     tork.ScheduledJobStateActive,
@@ -1519,6 +1520,7 @@ func TestPostgresGetActiveScheduledJobs(t *testing.T) {
 	sj2 := &tork.ScheduledJob{
 		ID:        uuid.NewUUID(),
 		Name:      "Scheduled Job 2",
+		Cron:      "* * * * *",
 		CreatedAt: now,
 		CreatedBy: u,
 		State:     tork.ScheduledJobStatePaused,

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ retract v0.1.0
 require (
 	github.com/docker/cli v26.1.5+incompatible
 	github.com/docker/docker v26.1.5+incompatible
+	github.com/docker/go-connections v0.4.1-0.20231031175723-0b8c1f4e07a0
 	github.com/docker/go-units v0.5.0
 	github.com/expr-lang/expr v1.17.2
 	github.com/fatih/color v1.17.0
@@ -46,7 +47,6 @@ require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
-	github.com/docker/go-connections v0.4.1-0.20231031175723-0b8c1f4e07a0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.8 // indirect

--- a/internal/fns/fns.go
+++ b/internal/fns/fns.go
@@ -1,9 +1,16 @@
 package fns
 
-import "io"
+import (
+	"fmt"
+	"io"
+)
 
 // CloseIgnore closes c, ignoring any error.
 // Its main use is to satisfy linters.
 func CloseIgnore(c io.Closer) {
 	_ = c.Close()
+}
+
+func Fprintf(w io.Writer, format string, a ...any) {
+	_, _ = fmt.Fprintf(w, format, a...)
 }

--- a/internal/fns/fns_test.go
+++ b/internal/fns/fns_test.go
@@ -1,0 +1,94 @@
+package fns
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+)
+
+type mockCloser struct {
+	shouldError bool
+	closed      bool
+}
+
+func (m *mockCloser) Close() error {
+	m.closed = true
+	if m.shouldError {
+		return errors.New("mock error")
+	}
+	return nil
+}
+
+func TestCloseIgnore(t *testing.T) {
+	tests := []struct {
+		name           string
+		closer         *mockCloser
+		expectedClosed bool
+	}{
+		{
+			name:           "Close without error",
+			closer:         &mockCloser{shouldError: false},
+			expectedClosed: true,
+		},
+		{
+			name:           "Close with error",
+			closer:         &mockCloser{shouldError: true},
+			expectedClosed: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			CloseIgnore(tt.closer)
+			if tt.closer.closed != tt.expectedClosed {
+				t.Errorf("expected closed: %v, got: %v", tt.expectedClosed, tt.closer.closed)
+			}
+		})
+	}
+}
+
+func TestFprintf(t *testing.T) {
+	var buf bytes.Buffer
+	format := "Hello, %s!"
+	name := "World"
+	expected := "Hello, World!"
+
+	Fprintf(&buf, format, name)
+
+	if buf.String() != expected {
+		t.Errorf("expected: %q, got: %q", expected, buf.String())
+	}
+}
+
+func TestFprintf_EmptyWriter(t *testing.T) {
+	var buf bytes.Buffer
+	format := ""
+	expected := ""
+
+	Fprintf(&buf, format)
+
+	if buf.String() != expected {
+		t.Errorf("expected: %q, got: %q", expected, buf.String())
+	}
+}
+
+func TestFprintf_ErrorWriter(t *testing.T) {
+	errorWriter := &mockErrorWriter{}
+	format := "Hello, %s!"
+	name := "World"
+
+	Fprintf(errorWriter, format, name)
+
+	if !errorWriter.writeCalled {
+		t.Errorf("expected write to be called, but it was not")
+	}
+}
+
+type mockErrorWriter struct {
+	writeCalled bool
+}
+
+func (m *mockErrorWriter) Write(p []byte) (n int, err error) {
+	m.writeCalled = true
+	return 0, errors.New("mock write error")
+}

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -544,24 +544,3 @@ func Test_handleTaskRunDefaultLimitOK(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "/somevolume", t1.Mounts[0].Target)
 }
-
-func Test_reservePort(t *testing.T) {
-	rt, err := docker.NewDockerRuntime()
-	assert.NoError(t, err)
-
-	b := broker.NewInMemoryBroker()
-
-	w, err := NewWorker(Config{
-		Broker:  b,
-		Runtime: rt,
-	})
-	assert.NoError(t, err)
-	assert.NotNil(t, w)
-
-	port, err := w.reservePort()
-	assert.NoError(t, err)
-	assert.NotEmpty(t, port)
-	assert.Contains(t, w.usedPorts, port)
-	w.releasePort(port)
-	assert.NotContains(t, w.usedPorts, port)
-}

--- a/runtime/docker/tcontainer.go
+++ b/runtime/docker/tcontainer.go
@@ -1,0 +1,547 @@
+package docker
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	cliopts "github.com/docker/cli/opts"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/mount"
+	"github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/client"
+	"github.com/docker/docker/errdefs"
+	"github.com/docker/go-connections/nat"
+	"github.com/gosimple/slug"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
+	"github.com/runabol/tork"
+	"github.com/runabol/tork/broker"
+	"github.com/runabol/tork/internal/fns"
+	"github.com/runabol/tork/internal/uuid"
+	"github.com/runabol/tork/runtime"
+)
+
+type tcontainer struct {
+	id      string
+	client  *client.Client
+	mounter runtime.Mounter
+	broker  broker.Broker
+	task    *tork.Task
+	logger  io.Writer
+	torkdir *tork.Mount
+}
+
+func createTaskContainer(ctx context.Context, rt *DockerRuntime, t *tork.Task, logger io.Writer) (*tcontainer, error) {
+	if t.ID == "" {
+		return nil, errors.New("task id is required")
+	}
+	if err := rt.imagePull(ctx, t, logger); err != nil {
+		return nil, errors.Wrapf(err, "error pulling image: %s", t.Image)
+	}
+	env := []string{}
+	for name, value := range t.Env {
+		env = append(env, fmt.Sprintf("%s=%s", name, value))
+	}
+	env = append(env, "TORK_OUTPUT=/tork/stdout")
+	env = append(env, "TORK_PROGRESS=/tork/progress")
+
+	var mounts []mount.Mount
+
+	for _, m := range t.Mounts {
+		var mt mount.Type
+		switch m.Type {
+		case tork.MountTypeVolume:
+			mt = mount.TypeVolume
+			if m.Target == "" {
+				return nil, errors.Errorf("volume target is required")
+			}
+		case tork.MountTypeBind:
+			mt = mount.TypeBind
+			if m.Target == "" {
+				return nil, errors.Errorf("bind target is required")
+			}
+			if m.Source == "" {
+				return nil, errors.Errorf("bind source is required")
+			}
+		case tork.MountTypeTmpfs:
+			mt = mount.TypeTmpfs
+		default:
+			return nil, errors.Errorf("unknown mount type: %s", m.Type)
+		}
+		mount := mount.Mount{
+			Type:   mt,
+			Source: m.Source,
+			Target: m.Target,
+		}
+		log.Debug().Msgf("Mounting %s -> %s", mount.Source, mount.Target)
+		mounts = append(mounts, mount)
+	}
+
+	torkdir := &tork.Mount{
+		ID:     uuid.NewUUID(),
+		Type:   tork.MountTypeVolume,
+		Target: "/tork",
+	}
+	if err := rt.mounter.Mount(ctx, torkdir); err != nil {
+		return nil, err
+	}
+	mounts = append(mounts, mount.Mount{
+		Type:   mount.TypeVolume,
+		Source: torkdir.Source,
+		Target: torkdir.Target,
+	})
+
+	// parse task limits
+	cpus, err := parseCPUs(t.Limits)
+	if err != nil {
+		return nil, errors.Wrapf(err, "invalid CPUs value")
+	}
+	mem, err := parseMemory(t.Limits)
+	if err != nil {
+		return nil, errors.Wrapf(err, "invalid memory value")
+	}
+
+	resources := container.Resources{
+		NanoCPUs: cpus,
+		Memory:   mem,
+	}
+
+	if t.GPUs != "" {
+		gpuOpts := cliopts.GpuOpts{}
+		if err := gpuOpts.Set(t.GPUs); err != nil {
+			return nil, errors.Wrapf(err, "error setting GPUs")
+		}
+		resources.DeviceRequests = gpuOpts.Value()
+	}
+
+	cmd := t.CMD
+	if len(cmd) == 0 {
+		cmd = []string{"/tork/entrypoint"}
+	}
+	entrypoint := t.Entrypoint
+	if len(entrypoint) == 0 && t.Run != "" {
+		entrypoint = []string{"sh", "-c"}
+	}
+	containerConf := container.Config{
+		Image:      t.Image,
+		Env:        env,
+		Cmd:        cmd,
+		Entrypoint: entrypoint,
+	}
+
+	hc := container.HostConfig{
+		PublishAllPorts: false,
+		Mounts:          mounts,
+		Resources:       resources,
+		Privileged:      rt.privileged,
+	}
+
+	if t.Probe != nil {
+		containerConf.ExposedPorts = nat.PortSet{
+			nat.Port(fmt.Sprintf("%d/tcp", t.Probe.Port)): struct{}{}, // Expose the probe port
+		}
+
+		hc.PortBindings = nat.PortMap{
+			nat.Port(fmt.Sprintf("%d/tcp", t.Probe.Port)): []nat.PortBinding{
+				{
+					HostIP:   "localhost",
+					HostPort: "0", // Let Docker assign a random port
+				},
+			},
+		}
+	}
+
+	// we want to override the default
+	// image WORKDIR only if the task
+	// introduces work files _or_ if the
+	// user specifies a WORKDIR
+	if t.Workdir != "" {
+		containerConf.WorkingDir = t.Workdir
+	} else if len(t.Files) > 0 {
+		t.Workdir = defaultWorkdir
+		containerConf.WorkingDir = t.Workdir
+	}
+
+	nc := network.NetworkingConfig{
+		EndpointsConfig: make(map[string]*network.EndpointSettings),
+	}
+
+	for _, nw := range t.Networks {
+		endpoint := &network.EndpointSettings{
+			NetworkID: nw,
+			Aliases:   []string{slug.Make(t.Name)},
+		}
+		nc.EndpointsConfig[nw] = endpoint
+	}
+
+	// we want to create the container using a background context
+	// in case the task is being cancelled while the container is
+	// being created. This could lead to a situation where the
+	// container is created in a "zombie" state leading to a situation
+	// where the attached volumes can't be removed and cleaned up.
+	createCtx, createCancel := context.WithTimeout(context.Background(), time.Second*30)
+	defer createCancel()
+	resp, err := rt.client.ContainerCreate(
+		createCtx, &containerConf, &hc, &nc, nil, "")
+	if err != nil {
+		log.Error().Msgf(
+			"Error creating container using image %s: %v\n",
+			t.Image, err,
+		)
+		return nil, err
+	}
+
+	tc := &tcontainer{
+		id:      resp.ID,
+		client:  rt.client,
+		mounter: rt.mounter,
+		broker:  rt.broker,
+		task:    t,
+		torkdir: torkdir,
+		logger:  logger,
+	}
+
+	// initialize the tork and, optionally, the work directory
+	if err := tc.initTorkdir(ctx); err != nil {
+		return nil, errors.Wrapf(err, "error initializing torkdir")
+	}
+
+	if err := tc.initWorkDir(ctx); err != nil {
+		return nil, errors.Wrapf(err, "error initializing workdir")
+	}
+
+	log.Debug().Msgf("Created container %s", tc.id)
+
+	return tc, nil
+}
+
+func (tc *tcontainer) Start(ctx context.Context) error {
+	// start the container
+	log.Debug().Msgf("Starting container %s", tc.id)
+	err := tc.client.ContainerStart(
+		ctx, tc.id, container.StartOptions{})
+	if err != nil {
+		return errors.Wrapf(err, "error starting container %s: %v\n", tc.id, err)
+	}
+
+	// wait for the container to be ready
+	if err := tc.probeContainer(ctx); err != nil {
+		return errors.Wrapf(err, "error waiting for container %s to be ready", tc.id)
+	}
+
+	return nil
+}
+
+func (tc *tcontainer) Remove(ctx context.Context) error {
+	log.Debug().Msgf("Attempting to stop and remove container %v", tc.id)
+	if err := tc.client.ContainerRemove(ctx, tc.id, container.RemoveOptions{
+		RemoveVolumes: true,
+		RemoveLinks:   false,
+		Force:         true,
+	}); err != nil {
+		return err
+	}
+	if err := tc.mounter.Unmount(ctx, tc.torkdir); err != nil {
+		return errors.Wrapf(err, "error unmounting torkdir %s", tc.torkdir.ID)
+	}
+	return nil
+}
+
+func (tc *tcontainer) Wait(ctx context.Context) (string, error) {
+	// report task progress
+	pctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go tc.reportProgress(pctx)
+
+	// read the container's stdout
+	out, err := tc.client.ContainerLogs(
+		ctx,
+		tc.id,
+		container.LogsOptions{
+			ShowStdout: true,
+			ShowStderr: true,
+			Follow:     true,
+		},
+	)
+	if err != nil {
+		return "", errors.Wrapf(err, "error getting logs for container %s: %v\n", tc.id, err)
+	}
+	// close the stdout reader
+	defer func() {
+		if err := out.Close(); err != nil {
+			log.Error().Err(err).Msgf("error closing stdout on container %s", tc.id)
+		}
+	}()
+	// copy the container's stdout to the logger
+	go func() {
+		_, err = io.Copy(tc.logger, dockerLogsReader{reader: out})
+		if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, context.Canceled) {
+			log.Error().Err(err).Msgf("error reading the std out")
+		}
+	}()
+	// wait for the task to finish execution
+	statusCh, errCh := tc.client.ContainerWait(ctx, tc.id, container.WaitConditionNotRunning)
+	select {
+	case err := <-errCh: // error waiting for the container to finish
+		return "", err
+	case status := <-statusCh:
+		if status.StatusCode != 0 { // error
+			out, err := tc.client.ContainerLogs(
+				ctx,
+				tc.id,
+				container.LogsOptions{
+					ShowStdout: true,
+					ShowStderr: true,
+					Tail:       "10",
+				},
+			)
+			if err != nil {
+				log.Error().Err(err).Msg("error tailing the log")
+				return "", errors.Errorf("exit code %d", status.StatusCode)
+			}
+			buf, err := io.ReadAll(dockerLogsReader{reader: out})
+			if err != nil {
+				log.Error().Err(err).Msg("error copying the output")
+			}
+			return "", errors.Errorf("exit code %d: %s", status.StatusCode, string(buf))
+		} else {
+			stdout, err := tc.readOutput(ctx)
+			if err != nil {
+				return "", err
+			}
+			log.Debug().
+				Int64("status-code", status.StatusCode).
+				Str("task-id", tc.task.ID).
+				Msg("task completed")
+			return stdout, nil
+		}
+	}
+
+}
+
+func (tc *tcontainer) probeContainer(ctx context.Context) error {
+	if tc.task.Probe == nil {
+		return nil
+	}
+
+	if tc.task.Probe.Path == "" {
+		tc.task.Probe.Path = "/" // Default path if not specified
+	}
+
+	if tc.task.Probe.Timeout == "" {
+		tc.task.Probe.Timeout = "1m" // Default timeout if not specified
+	}
+
+	// If there's a probe, get the assigned host port
+	insp, err := tc.client.ContainerInspect(ctx, tc.id)
+	if err != nil {
+		return errors.Wrapf(err, "error inspecting container %s", tc.id)
+	}
+	portStr := insp.NetworkSettings.Ports[nat.Port(fmt.Sprintf("%d/tcp", tc.task.Probe.Port))][0].HostPort
+	portNum, err := strconv.Atoi(portStr)
+	if err != nil {
+		return errors.Wrapf(err, "error parsing assigned port %s", portStr)
+	}
+
+	probeURL := fmt.Sprintf("http://localhost:%d%s", portNum, tc.task.Probe.Path)
+	client := &http.Client{
+		Timeout: time.Second * 3,
+		Transport: &http.Transport{
+			DialContext: (&net.Dialer{
+				Timeout: time.Second * 3,
+			}).DialContext,
+		},
+	}
+
+	timeout, err := time.ParseDuration(tc.task.Probe.Timeout)
+	if err != nil {
+		return errors.Wrapf(err, "error parsing probe timeout %s", tc.task.Probe.Timeout)
+	}
+
+	probeCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	for {
+		select {
+		case <-probeCtx.Done():
+			return errors.New("probe timed out after 1 minute")
+		case <-time.After(time.Second):
+			req, err := http.NewRequestWithContext(probeCtx, http.MethodGet, probeURL, nil)
+			if err != nil {
+				fns.Fprintf(tc.logger, "Failed to create probe request for container %s. Retrying...\n", tc.id)
+				continue
+			}
+			res, err := client.Do(req)
+			if err != nil {
+				fns.Fprintf(tc.logger, "Probe failed for container %s: %v. Retrying...\n", tc.id, err)
+				continue
+			}
+			fns.CloseIgnore(res.Body)
+			if res.StatusCode == http.StatusOK {
+				return nil
+			} else {
+				fns.Fprintf(tc.logger, "Probe for container %s returned status code %d. Retrying...\n", tc.id, res.StatusCode)
+			}
+		}
+	}
+}
+
+func (tc *tcontainer) reportProgress(ctx context.Context) {
+	for {
+		progress, err := tc.readProgress(ctx)
+		if err != nil {
+			var notFoundError errdefs.ErrNotFound
+			if errors.As(err, &notFoundError) {
+				return // progress file not found
+			}
+			if errors.Is(err, context.Canceled) {
+				return
+			}
+			log.Warn().Err(err).Msgf("error reading progress value")
+		} else {
+			if progress != tc.task.Progress {
+				tc.task.Progress = progress
+				if err := tc.broker.PublishTaskProgress(ctx, tc.task); err != nil {
+					log.Warn().Err(err).Msgf("error publishing task progress")
+				}
+			}
+		}
+		select {
+		case <-time.After(time.Second * 10):
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (tc *tcontainer) readOutput(ctx context.Context) (string, error) {
+	r, _, err := tc.client.CopyFromContainer(ctx, tc.id, "/tork/stdout")
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		err := r.Close()
+		if err != nil {
+			log.Error().Err(err).Msgf("error closing /tork/stdout reader")
+		}
+	}()
+	tr := tar.NewReader(r)
+	var buf bytes.Buffer
+	for {
+		_, err := tr.Next()
+		if err == io.EOF {
+			break // End of archive
+		}
+		if err != nil {
+			return "", err
+		}
+
+		if _, err := io.Copy(&buf, tr); err != nil {
+			return "", err
+		}
+	}
+	return buf.String(), nil
+}
+
+func (tc *tcontainer) readProgress(ctx context.Context) (float64, error) {
+	r, _, err := tc.client.CopyFromContainer(ctx, tc.id, "/tork/progress")
+	if err != nil {
+		return 0, err
+	}
+	defer func() {
+		err := r.Close()
+		if err != nil {
+			log.Error().Err(err).Msgf("error closing /tork/progress reader")
+		}
+	}()
+	tr := tar.NewReader(r)
+	var buf bytes.Buffer
+	for {
+		_, err := tr.Next()
+		if err == io.EOF {
+			break // End of archive
+		}
+		if err != nil {
+			return 0, err
+		}
+
+		if _, err := io.Copy(&buf, tr); err != nil {
+			return 0, err
+		}
+	}
+	s := strings.TrimSpace(buf.String())
+	if s == "" {
+		return 0, nil
+	}
+	return strconv.ParseFloat(s, 32)
+}
+
+func (tc *tcontainer) initTorkdir(ctx context.Context) error {
+	ar, err := NewTempArchive()
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		if err := ar.Remove(); err != nil {
+			log.Error().Err(err).Msgf("error removing temp archive: %s", ar.Name())
+		}
+	}()
+
+	if err := ar.WriteFile("stdout", 0222, []byte{}); err != nil {
+		return err
+	}
+	if err := ar.WriteFile("progress", 0222, []byte{}); err != nil {
+		return err
+	}
+
+	if tc.task.Run != "" {
+		if err := ar.WriteFile("entrypoint", 0555, []byte(tc.task.Run)); err != nil {
+			return err
+		}
+	}
+
+	if err := tc.client.CopyToContainer(ctx, tc.id, "/tork", ar, types.CopyToContainerOptions{}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (tc *tcontainer) initWorkDir(ctx context.Context) (err error) {
+	if len(tc.task.Files) == 0 {
+		return
+	}
+
+	ar, err := NewTempArchive()
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		if err := ar.Remove(); err != nil {
+			log.Error().Err(err).Msgf("error removing temp archive: %s", ar.Name())
+		}
+	}()
+
+	for filename, contents := range tc.task.Files {
+		if err := ar.WriteFile(filename, 0444, []byte(contents)); err != nil {
+			return err
+		}
+	}
+
+	if err := tc.client.CopyToContainer(ctx, tc.id, tc.task.Workdir, ar, types.CopyToContainerOptions{}); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/runtime/docker/volume.go
+++ b/runtime/docker/volume.go
@@ -37,6 +37,7 @@ func (m *VolumeMounter) Mount(ctx context.Context, mn *tork.Mount) error {
 }
 
 func (m *VolumeMounter) Unmount(ctx context.Context, mn *tork.Mount) error {
+	log.Debug().Msgf("removing volume %s", mn.Source)
 	ls, err := m.client.VolumeList(ctx, volume.ListOptions{Filters: filters.NewArgs(filters.Arg("name", mn.Source))})
 	if err != nil {
 		return err

--- a/runtime/shell/shell_test.go
+++ b/runtime/shell/shell_test.go
@@ -205,26 +205,3 @@ func TestRunTaskWithPrePost(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "hello pre\n", t1.Result)
 }
-
-func TestRunTaskWithSidecar(t *testing.T) {
-	rt := NewShellRuntime(Config{
-		UID: DEFAULT_UID,
-		GID: DEFAULT_GID,
-		Rexec: func(args ...string) *exec.Cmd {
-			cmd := exec.Command(args[5], args[6:]...)
-			return cmd
-		},
-	})
-
-	t1 := &tork.Task{
-		ID:  uuid.NewUUID(),
-		Run: "sleep 1.5; cat /tmp/sidecar > $REEXEC_TORK_OUTPUT",
-		Sidecars: []*tork.Task{{
-			Run: "echo hello sidecar > /tmp/sidecar",
-		}},
-	}
-
-	err := rt.Run(context.Background(), t1)
-	assert.NoError(t, err)
-	assert.Equal(t, "hello sidecar\n", t1.Result)
-}

--- a/task.go
+++ b/task.go
@@ -73,6 +73,7 @@ type Task struct {
 	Workdir     string            `json:"workdir,omitempty"`
 	Priority    int               `json:"priority,omitempty"`
 	Progress    float64           `json:"progress,omitempty"`
+	Probe       *Probe            `json:"probe,omitempty"`
 }
 
 type TaskSummary struct {
@@ -144,6 +145,12 @@ type Registry struct {
 	Password string `json:"password,omitempty"`
 }
 
+type Probe struct {
+	Path    string `json:"path,omitempty"`
+	Port    int    `json:"port,omitempty"`
+	Timeout string `json:"timeout,omitempty"`
+}
+
 func (t *Task) IsActive() bool {
 	return slices.Contains(TaskStateActive, t.State)
 }
@@ -172,6 +179,10 @@ func (t *Task) Clone() *Task {
 	var registry *Registry
 	if t.Registry != nil {
 		registry = t.Registry.Clone()
+	}
+	var probe *Probe
+	if t.Probe != nil {
+		probe = t.Probe.Clone()
 	}
 	return &Task{
 		ID:          t.ID,
@@ -215,6 +226,7 @@ func (t *Task) Clone() *Task {
 		Workdir:     t.Workdir,
 		Priority:    t.Priority,
 		Progress:    t.Progress,
+		Probe:       probe,
 	}
 }
 
@@ -282,6 +294,14 @@ func (r *Registry) Clone() *Registry {
 	return &Registry{
 		Username: r.Username,
 		Password: r.Password,
+	}
+}
+
+func (p *Probe) Clone() *Probe {
+	return &Probe{
+		Path:    p.Path,
+		Port:    p.Port,
+		Timeout: p.Timeout,
 	}
 }
 


### PR DESCRIPTION
This pull request introduces a new `probe` feature for sidecar containers in job configurations. The feature enables health checking for `sidecar` services by sending HTTP requests to a specified `path` and port, ensuring the `sidecar` is ready before the main task executes.

```yaml
name: job
tasks:
  - name: task1
    run: pip install requests; python -u script.py
    image: python:3.11-alpine
    files:
      script.py: |
        import requests
        print(f'Response: {requests.get("http://myserver:9000").text}')
    sidecars:
      - name: myserver
        run: python -u server.py
        image: python:3.11-alpine
        files:
          server.py: |-
            from http.server import BaseHTTPRequestHandler, HTTPServer
            from datetime import datetime
            class Handler(BaseHTTPRequestHandler):
              def do_GET(self):
                self.send_response(200); self.send_header('Content-type', 'text/plain'); self.end_headers()
                self.wfile.write(f'Server: {datetime.now().isoformat()}'.encode())
            HTTPServer(('0.0.0.0', 9000), Handler).serve_forever()
        probe:
          path: /
          port: 9000
          timeout: 10s # default is 1 minute
```