### PR TITLE
chore: Updated toml config and tork binary build process

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -4,7 +4,7 @@ tmp_dir = "tmp"
 
 [build]
   args_bin = ["run", "standalone"]
-  bin = "./tork"
+  bin = "./tmp/tork"
   cmd = "make"
   delay = 1000
   exclude_dir = ["assets", "tmp", "vendor", "testdata"]

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
-tork
+.git/
+tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,5 @@ go.work
 config.local.toml
 
 # Binaries
-tork
 tmp/
 config.toml

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile for building Tork
 GITCOMMIT:=$(shell git describe --dirty --always)
-BINARY:=tork
+BINARY:=./tmp/tork
 SYSTEM:=
 CHECKS:=check
 BUILDOPTS:=-v

--- a/configs/sample.config.toml
+++ b/configs/sample.config.toml
@@ -12,7 +12,7 @@ format = "pretty" # pretty | json
 type = "inmemory" # inmemory | rabbitmq
 
 [broker.rabbitmq]
-url = "amqp://guest:guest@localhost:5672/"
+url = "amqp://guest:guest@localhost:5672/" # or "amqp://guest:guest@host.docker.internal:5672/" if using devcontainers
 consumer.timeout = "30m"
 management.url = ""                        # default: http://{rabbit_host}:15672/
 durable.queues = false
@@ -28,7 +28,7 @@ jobs.duration = "8760h" # 1 year
 dsn = "host=localhost user=tork password=tork dbname=tork port=5432 sslmode=disable"
 
 [coordinator]
-address = "localhost:8000"
+address = "localhost:8000" # or "host.docker.internal:8000" if using devcontainers
 name = "Coordinator"
 
 [coordinator.api]


### PR DESCRIPTION
- Updated the `sample.config.toml` to include a comment to point towards `host.docker.internal` when using devcontainers.
- Moved where the tork binary will be built to follow the default Golang set up e.g. it's usually placed under `tmp` folder.