### PR TITLE
Feature: support rabbitmq quorum queues

### DIFF
--- a/configs/sample.config.toml
+++ b/configs/sample.config.toml
@@ -16,6 +16,7 @@ url = "amqp://guest:guest@localhost:5672/" # or "amqp://guest:guest@host.docker.
 consumer.timeout = "30m"
 management.url = ""                        # default: http://{rabbit_host}:15672/
 durable.queues = false
+queue.type = "classic"
 
 [datastore]
 type = "postgres"

--- a/engine/broker.go
+++ b/engine/broker.go
@@ -149,6 +149,7 @@ func (e *Engine) createBroker(btype string) (broker.Broker, error) {
 			broker.WithConsumerTimeoutMS(conf.DurationDefault("broker.rabbitmq.consumer.timeout", broker.RABBITMQ_DEFAULT_CONSUMER_TIMEOUT)),
 			broker.WithManagementURL(conf.String("broker.rabbitmq.management.url")),
 			broker.WithDurableQueues(conf.Bool("broker.rabbitmq.durable.queues")),
+			broker.WithQueueType(conf.StringDefault("broker.rabbitmq.queue.type", broker.RABBITMQ_QUEUE_TYPE_CLASSIC)),
 		)
 		if err != nil {
 			return nil, errors.Wrapf(err, "unable to connect to RabbitMQ")


### PR DESCRIPTION
This PR introduces optional support for using Quorum queues when RabbitMQ is configured as the broker in Tork. Quorum queues provide enhanced durability and high availability through Raft-based replication, making them suitable for production environments requiring stronger data safety guarantees compared to classic queues.

**Changes**
* Added a new environment variable `TORK_BROKER_RABBITMQ_QUEUE_TYPE`, which defaults to classic.
* When set to `quorum`, Tork will declare all relevant queues (e.g., task queues managed by the Broker) as Quorum queues instead of `classic` ones.
* No changes to the default behavior—`classic` queues remain the standard to ensure backward compatibility.

**Testing and Caveats**
Quorum queues do not map 1:1 with classic queues in terms of behavior, migration, or performance characteristics. For instance:

Quorum queues require RabbitMQ clusters with an odd number of nodes for proper replication.
Existing data in classic queues cannot be directly migrated to Quorum queues without manual intervention.
Users are strongly encouraged to test this feature thoroughly in a staging environment before enabling it in production to avoid potential disruptions to workflows.

For more details on Quorum queues, see the official RabbitMQ documentation: [https://www.rabbitmq.com/quorum-queues.html](https://www.rabbitmq.com/quorum-queues.html)