### PR TITLE
Add support for mount opts

### DIFF
--- a/broker/inmemory_test.go
+++ b/broker/inmemory_test.go
@@ -25,7 +25,7 @@ func TestInMemoryPublishAndSubsribeForTask(t *testing.T) {
 
 	t1 := &tork.Task{
 		ID: uuid.NewUUID(),
-		Mounts: []tork.Mount{
+		Mounts: []*tork.Mount{
 			{
 				Type:   tork.MountTypeVolume,
 				Target: "/somevolume",

--- a/datastore/postgres/record.go
+++ b/datastore/postgres/record.go
@@ -230,7 +230,7 @@ func (r taskRecord) toTask() (*tork.Task, error) {
 			return nil, errors.Wrapf(err, "error deserializing task.registry")
 		}
 	}
-	var mounts []tork.Mount
+	var mounts []*tork.Mount
 	if r.Mounts != nil {
 		if err := json.Unmarshal(r.Mounts, &mounts); err != nil {
 			return nil, errors.Wrapf(err, "error deserializing task.registry")

--- a/input/task.go
+++ b/input/task.go
@@ -74,9 +74,10 @@ type Registry struct {
 }
 
 type Mount struct {
-	Type   string `json:"type,omitempty" yaml:"type,omitempty"`
-	Source string `json:"source,omitempty" yaml:"source,omitempty"`
-	Target string `json:"target,omitempty" yaml:"target,omitempty"`
+	Type   string            `json:"type,omitempty" yaml:"type,omitempty"`
+	Source string            `json:"source,omitempty" yaml:"source,omitempty"`
+	Target string            `json:"target,omitempty" yaml:"target,omitempty"`
+	Opts   map[string]string `json:"opts,omitempty" yaml:"opts,omitempty"`
 }
 
 type AuxTask struct {
@@ -112,11 +113,12 @@ type Probe struct {
 	Timeout string `json:"timeout,omitempty" yaml:"timeout,omitempty" validate:"duration"`
 }
 
-func (m Mount) toMount() tork.Mount {
-	return tork.Mount{
+func (m Mount) toMount() *tork.Mount {
+	return &tork.Mount{
 		Type:   m.Type,
 		Source: m.Source,
 		Target: m.Target,
+		Opts:   maps.Clone(m.Opts),
 	}
 }
 
@@ -260,8 +262,8 @@ func (i Task) toTask() *tork.Task {
 	}
 }
 
-func toMounts(ms []Mount) []tork.Mount {
-	result := make([]tork.Mount, len(ms))
+func toMounts(ms []Mount) []*tork.Mount {
+	result := make([]*tork.Mount, len(ms))
 	for i, m := range ms {
 		result[i] = m.toMount()
 	}

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -70,6 +70,10 @@ func (r *Redacter) doRedactTask(t *tork.Task, secrets map[string]string) {
 	redacted := t
 	// redact env vars
 	redacted.Env = r.redactVars(redacted.Env, secrets)
+	// redact mounts
+	for _, m := range redacted.Mounts {
+		m.Opts = r.redactVars(m.Opts, secrets)
+	}
 	// redact pre tasks
 	for _, p := range redacted.Pre {
 		r.doRedactTask(p, secrets)

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -68,6 +68,13 @@ func TestRedactTask(t *testing.T) {
 			Username: "me",
 			Password: "secret",
 		},
+		Mounts: []*tork.Mount{
+			{
+				Opts: map[string]string{
+					"secret": "secret",
+				},
+			},
+		},
 	}
 
 	redacter := NewRedacter(ds)
@@ -89,6 +96,7 @@ func TestRedactTask(t *testing.T) {
 	assert.Equal(t, "[REDACTED]", ta.Registry.Password)
 	assert.Equal(t, "[REDACTED]", ta.Env["thing"])
 	assert.Equal(t, "[REDACTED]", ta.SubJob.Secrets["hush"])
+	assert.Equal(t, "[REDACTED]", ta.Mounts[0].Opts["secret"])
 	assert.NoError(t, ds.Close())
 }
 

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -81,7 +81,7 @@ func Test_handleTaskRun(t *testing.T) {
 		State: tork.TaskStateRunning,
 		Image: "ubuntu:mantic",
 		CMD:   []string{"ls"},
-		Mounts: []tork.Mount{
+		Mounts: []*tork.Mount{
 			{
 				Type:   tork.MountTypeVolume,
 				Target: "/somevolume",
@@ -154,7 +154,7 @@ func Test_handleTaskRunWithPrePost(t *testing.T) {
 		State: tork.TaskStateRunning,
 		Image: "ubuntu:mantic",
 		Run:   "cat /somevolume/pre > $TORK_OUTPUT",
-		Mounts: []tork.Mount{
+		Mounts: []*tork.Mount{
 			{
 				Type:   tork.MountTypeVolume,
 				Target: "/somevolume",
@@ -472,7 +472,7 @@ func Test_handleTaskRunDefaultLimitExceeded(t *testing.T) {
 		State: tork.TaskStateRunning,
 		Image: "ubuntu:mantic",
 		CMD:   []string{"sleep", "5"},
-		Mounts: []tork.Mount{
+		Mounts: []*tork.Mount{
 			{
 				Type:   tork.MountTypeVolume,
 				Target: "/somevolume",
@@ -528,7 +528,7 @@ func Test_handleTaskRunDefaultLimitOK(t *testing.T) {
 		State: tork.TaskStateRunning,
 		Image: "ubuntu:mantic",
 		CMD:   []string{"sleep", "1"},
-		Mounts: []tork.Mount{
+		Mounts: []*tork.Mount{
 			{
 				Type:   tork.MountTypeVolume,
 				Target: "/somevolume",

--- a/mount.go
+++ b/mount.go
@@ -1,5 +1,7 @@
 package tork
 
+import "golang.org/x/exp/maps"
+
 const (
 	MountTypeVolume string = "volume"
 	MountTypeBind   string = "bind"
@@ -7,8 +9,27 @@ const (
 )
 
 type Mount struct {
-	ID     string `json:"-"`
-	Type   string `json:"type,omitempty"`
-	Source string `json:"source,omitempty"`
-	Target string `json:"target,omitempty"`
+	ID     string            `json:"-"`
+	Type   string            `json:"type,omitempty"`
+	Source string            `json:"source,omitempty"`
+	Target string            `json:"target,omitempty"`
+	Opts   map[string]string `json:"opts,omitempty"`
+}
+
+func (m *Mount) Clone() *Mount {
+	return &Mount{
+		ID:     m.ID,
+		Type:   m.Type,
+		Source: m.Source,
+		Target: m.Target,
+		Opts:   maps.Clone(m.Opts),
+	}
+}
+
+func CloneMounts(mounts []*Mount) []*Mount {
+	copy := make([]*Mount, len(mounts))
+	for i, m := range mounts {
+		copy[i] = m.Clone()
+	}
+	return copy
 }

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -169,13 +169,13 @@ func (rt *DockerRuntime) Run(ctx context.Context, t *tork.Task) error {
 	// prepare mounts
 	for i, mnt := range t.Mounts {
 		mnt.ID = uuid.NewUUID()
-		err := rt.mounter.Mount(ctx, &mnt)
+		err := rt.mounter.Mount(ctx, mnt)
 		if err != nil {
 			return err
 		}
-		defer func(m tork.Mount) {
+		defer func(m *tork.Mount) {
 			log.Debug().Msgf("Unmounting %s: %s", m.Type, m.Target)
-			if err := rt.mounter.Unmount(context.Background(), &m); err != nil {
+			if err := rt.mounter.Unmount(context.Background(), m); err != nil {
 				log.Error().
 					Err(err).
 					Msgf("error deleting mount: %s", m)

--- a/runtime/docker/docker_test.go
+++ b/runtime/docker/docker_test.go
@@ -289,7 +289,7 @@ func TestRunTaskWithVolume(t *testing.T) {
 		ID:    uuid.NewUUID(),
 		Image: "busybox:stable",
 		Run:   "echo hello world > /xyz/thing",
-		Mounts: []tork.Mount{
+		Mounts: []*tork.Mount{
 			{
 				Type:   tork.MountTypeVolume,
 				Target: "/xyz",
@@ -311,7 +311,7 @@ func TestRunTaskWithVolumeAndCustomWorkdir(t *testing.T) {
 		Image: "busybox:stable",
 		Run: `echo hello world > /xyz/thing
               ls > $TORK_OUTPUT`,
-		Mounts: []tork.Mount{
+		Mounts: []*tork.Mount{
 			{
 				Type:   tork.MountTypeVolume,
 				Target: "/xyz",
@@ -338,7 +338,7 @@ func TestRunTaskWithBind(t *testing.T) {
 		ID:    uuid.NewUUID(),
 		Image: "busybox:stable",
 		Run:   "echo hello world > /xyz/thing",
-		Mounts: []tork.Mount{{
+		Mounts: []*tork.Mount{{
 			Type:   tork.MountTypeBind,
 			Target: "/xyz",
 			Source: dir,
@@ -360,7 +360,7 @@ func TestRunTaskWithTempfs(t *testing.T) {
 		ID:    uuid.NewUUID(),
 		Image: "busybox:stable",
 		Run:   "echo hello world > /xyz/thing",
-		Mounts: []tork.Mount{
+		Mounts: []*tork.Mount{
 			{
 				Type:   tork.MountTypeTmpfs,
 				Target: "/xyz",
@@ -381,7 +381,7 @@ func TestRunTaskWithVolumeAndWorkdir(t *testing.T) {
 		ID:    uuid.NewUUID(),
 		Image: "busybox:stable",
 		Run:   "echo hello world > ./thing",
-		Mounts: []tork.Mount{
+		Mounts: []*tork.Mount{
 			{
 				Type:   tork.MountTypeVolume,
 				Target: "/xyz",
@@ -405,7 +405,7 @@ func TestRunTaskWithTempfsAndWorkdir(t *testing.T) {
 		ID:    uuid.NewUUID(),
 		Image: "busybox:stable",
 		Run:   "echo hello world > ./thing",
-		Mounts: []tork.Mount{
+		Mounts: []*tork.Mount{
 			{
 				Type:   tork.MountTypeTmpfs,
 				Target: "/xyz",
@@ -464,7 +464,7 @@ func TestRunTaskWithCustomMounter(t *testing.T) {
 		ID:    uuid.NewUUID(),
 		Image: "busybox:stable",
 		Run:   "echo hello world > /xyz/thing",
-		Mounts: []tork.Mount{
+		Mounts: []*tork.Mount{
 			{
 				Type:   tork.MountTypeVolume,
 				Target: "/xyz",
@@ -618,7 +618,7 @@ func TestRunTaskWithPrePost(t *testing.T) {
 			Image: "busybox:stable",
 			Run:   "echo bye bye",
 		}},
-		Mounts: []tork.Mount{
+		Mounts: []*tork.Mount{
 			{
 				Type:   tork.MountTypeVolume,
 				Target: "/mnt",
@@ -664,7 +664,7 @@ func TestRunTaskWithSidecarAndMount(t *testing.T) {
 			Image: "busybox:stable",
 			Run:   "echo hello sidecar > /mnt/sidecar",
 		}},
-		Mounts: []tork.Mount{
+		Mounts: []*tork.Mount{
 			{
 				Type:   tork.MountTypeVolume,
 				Target: "/mnt",
@@ -725,7 +725,7 @@ func TestRunTaskWithPreWithError(t *testing.T) {
 			Image: "busybox:stable",
 			Run:   "bad_thing",
 		}},
-		Mounts: []tork.Mount{
+		Mounts: []*tork.Mount{
 			{
 				Type:   tork.MountTypeVolume,
 				Target: "/mnt",

--- a/runtime/docker/volume.go
+++ b/runtime/docker/volume.go
@@ -27,7 +27,7 @@ func NewVolumeMounter() (*VolumeMounter, error) {
 func (m *VolumeMounter) Mount(ctx context.Context, mn *tork.Mount) error {
 	name := uuid.NewUUID()
 	mn.Source = name
-	v, err := m.client.VolumeCreate(ctx, volume.CreateOptions{Name: name})
+	v, err := m.client.VolumeCreate(ctx, volume.CreateOptions{Name: name, DriverOpts: mn.Opts})
 	if err != nil {
 		return err
 	}

--- a/runtime/docker/volume_test.go
+++ b/runtime/docker/volume_test.go
@@ -57,3 +57,22 @@ func Test_createMountVolume(t *testing.T) {
 	assert.Equal(t, "/somevol", mnt.Target)
 	assert.NotEmpty(t, mnt.Source)
 }
+
+func Test_createMountVolumeWithOpts(t *testing.T) {
+	m, err := NewVolumeMounter()
+	assert.NoError(t, err)
+
+	mnt := &tork.Mount{
+		Type:   tork.MountTypeVolume,
+		Target: "/somevol",
+		Opts:   map[string]string{"type": "tmpfs", "device": "tmpfs"},
+	}
+	err = m.Mount(context.Background(), mnt)
+	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, m.Unmount(context.Background(), mnt))
+	}()
+	assert.Equal(t, "/somevol", mnt.Target)
+	assert.NotEmpty(t, mnt.Source)
+	assert.Equal(t, map[string]string{"type": "tmpfs", "device": "tmpfs"}, mnt.Opts)
+}

--- a/runtime/podman/podman.go
+++ b/runtime/podman/podman.go
@@ -101,13 +101,13 @@ func (d *PodmanRuntime) Run(ctx context.Context, t *tork.Task) error {
 	// prepare mounts
 	for i, mnt := range t.Mounts {
 		mnt.ID = uuid.NewUUID()
-		err := d.mounter.Mount(ctx, &mnt)
+		err := d.mounter.Mount(ctx, mnt)
 		if err != nil {
 			return err
 		}
-		defer func(m tork.Mount) {
+		defer func(m *tork.Mount) {
 			log.Debug().Msgf("Unmounting %s: %s", m.Type, m.Target)
-			if err := d.mounter.Unmount(context.Background(), &m); err != nil {
+			if err := d.mounter.Unmount(context.Background(), m); err != nil {
 				log.Error().
 					Err(err).
 					Msgf("error deleting mount: %s", m)

--- a/runtime/podman/podman_test.go
+++ b/runtime/podman/podman_test.go
@@ -82,7 +82,7 @@ func TestPodmanRunPrePost(t *testing.T) {
 			Image: "busybox:stable",
 			Run:   "echo post",
 		}},
-		Mounts: []tork.Mount{{
+		Mounts: []*tork.Mount{{
 			Type:   tork.MountTypeVolume,
 			Target: "/somedir",
 		}},
@@ -271,7 +271,7 @@ func TestPodmanRunTaskWithVolume(t *testing.T) {
 		Name:  "Some task",
 		Image: "busybox:stable",
 		Run:   "echo hello world > /xyz/thing",
-		Mounts: []tork.Mount{
+		Mounts: []*tork.Mount{
 			{
 				Type:   tork.MountTypeVolume,
 				Target: "/xyz",
@@ -293,7 +293,7 @@ func TestPodmanRunTaskWithVolumeAndCustomWorkdir(t *testing.T) {
 		Image: "busybox:stable",
 		Run: `echo hello world > /xyz/thing
               ls > $TORK_OUTPUT`,
-		Mounts: []tork.Mount{
+		Mounts: []*tork.Mount{
 			{
 				Type:   tork.MountTypeVolume,
 				Target: "/xyz",
@@ -319,7 +319,7 @@ func TestPodmanRunTaskWithBind(t *testing.T) {
 		Name:  "Some task",
 		Image: "busybox:stable",
 		Run:   "echo hello world > /xyz/thing",
-		Mounts: []tork.Mount{{
+		Mounts: []*tork.Mount{{
 			Type:   tork.MountTypeBind,
 			Target: "/xyz",
 			Source: dir,
@@ -337,7 +337,7 @@ func TestPodmanRunTaskWithVolumeAndWorkdir(t *testing.T) {
 		Name:  "Some task",
 		Image: "busybox:stable",
 		Run:   "echo hello world > ./thing",
-		Mounts: []tork.Mount{
+		Mounts: []*tork.Mount{
 			{
 				Type:   tork.MountTypeVolume,
 				Target: "/xyz",
@@ -395,7 +395,7 @@ func TestRunTaskWithCustomMounter(t *testing.T) {
 		Name:  "Some task",
 		Image: "busybox:stable",
 		Run:   "echo hello world > /xyz/thing",
-		Mounts: []tork.Mount{
+		Mounts: []*tork.Mount{
 			{
 				Type:   tork.MountTypeVolume,
 				Target: "/xyz",
@@ -477,7 +477,7 @@ func TestRunTaskWithPrePost(t *testing.T) {
 			Image: "busybox:stable",
 			Run:   "echo bye bye",
 		}},
-		Mounts: []tork.Mount{
+		Mounts: []*tork.Mount{
 			{
 				Type:   tork.MountTypeVolume,
 				Target: "/mnt",

--- a/task.go
+++ b/task.go
@@ -57,7 +57,7 @@ type Task struct {
 	Pre         []*Task           `json:"pre,omitempty"`
 	Post        []*Task           `json:"post,omitempty"`
 	Sidecars    []*Task           `json:"sidecars,omitempty"`
-	Mounts      []Mount           `json:"mounts,omitempty"`
+	Mounts      []*Mount          `json:"mounts,omitempty"`
 	Networks    []string          `json:"networks,omitempty"`
 	NodeID      string            `json:"nodeId,omitempty"`
 	Retry       *TaskRetry        `json:"retry,omitempty"`
@@ -209,7 +209,7 @@ func (t *Task) Clone() *Task {
 		Pre:         CloneTasks(t.Pre),
 		Post:        CloneTasks(t.Post),
 		Sidecars:    CloneTasks(t.Sidecars),
-		Mounts:      slices.Clone(t.Mounts),
+		Mounts:      CloneMounts(t.Mounts),
 		Networks:    t.Networks,
 		NodeID:      t.NodeID,
 		Retry:       retry,


### PR DESCRIPTION
This PR adds support for `opts` on `mounts`. e.g.: 

```yaml
mounts:
  - type: volume
    target: /tmp
    opts:
      device: tmpfs
      o: size=100m,uid=1000
      type: tmpfs
```