### PR TITLE
Feature: max task redelivery

### DIFF
--- a/broker/queues.go
+++ b/broker/queues.go
@@ -32,6 +32,8 @@ const (
 	// The queue used by workers to send task
 	// progress to the Coordinator
 	QUEUE_PROGRESS = "progress"
+	// The queue used when a message is redelivered
+	QUEUE_REDELIVERIES = "redeliveries"
 	// The prefix used for queues that
 	// are exclusive
 	QUEUE_EXCLUSIVE_PREFIX = "x-"
@@ -54,6 +56,7 @@ func IsCoordinatorQueue(qname string) bool {
 		QUEUE_JOBS,
 		QUEUE_LOGS,
 		QUEUE_PROGRESS,
+		QUEUE_REDELIVERIES,
 	}
 	return slices.Contains(coordQueues, qname)
 }

--- a/internal/coordinator/handlers/redelivered.go
+++ b/internal/coordinator/handlers/redelivered.go
@@ -1,0 +1,45 @@
+package handlers
+
+import (
+	"context"
+	"time"
+
+	"github.com/rs/zerolog/log"
+	"github.com/runabol/tork"
+	"github.com/runabol/tork/broker"
+	"github.com/runabol/tork/datastore"
+	"github.com/runabol/tork/middleware/task"
+)
+
+const maxRedeliveries = 5
+
+type redeliveredHandler struct {
+	ds     datastore.Datastore
+	broker broker.Broker
+}
+
+func NewRedeliveredHandler(ds datastore.Datastore, b broker.Broker) task.HandlerFunc {
+	h := &redeliveredHandler{
+		ds:     ds,
+		broker: b,
+	}
+	return h.handle
+}
+
+func (h *redeliveredHandler) handle(ctx context.Context, et task.EventType, t *tork.Task) error {
+	log.Debug().
+		Str("task-id", t.ID).
+		Msg("received task redelivery")
+	if t.Redelivered >= maxRedeliveries {
+		log.Error().
+			Str("task-id", t.ID).
+			Msg("task redelivered too many times")
+		now := time.Now().UTC()
+		t.Error = "task redelivered too many times"
+		t.FailedAt = &now
+		t.State = tork.TaskStateFailed
+		return h.broker.PublishTask(ctx, broker.QUEUE_ERROR, t)
+	}
+	t.Redelivered++
+	return h.broker.PublishTask(ctx, t.Queue, t)
+}

--- a/internal/coordinator/handlers/redelivered_test.go
+++ b/internal/coordinator/handlers/redelivered_test.go
@@ -1,0 +1,39 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/runabol/tork"
+	"github.com/runabol/tork/broker"
+	"github.com/runabol/tork/datastore/postgres"
+	"github.com/runabol/tork/internal/uuid"
+	"github.com/runabol/tork/middleware/task"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_handleRedeliveredTask(t *testing.T) {
+	ctx := context.Background()
+	b := broker.NewInMemoryBroker()
+	ds, err := postgres.NewTestDatastore()
+	assert.NoError(t, err)
+	handler := NewRedeliveredHandler(ds, b)
+	assert.NotNil(t, handler)
+	t1 := &tork.Task{
+		ID:    uuid.NewUUID(),
+		State: tork.TaskStateRunning,
+	}
+	for i := 0; i < 5; i++ {
+		err = handler(ctx, task.Redelivered, t1)
+		assert.NoError(t, err)
+		assert.Equal(t, tork.TaskStateRunning, t1.State)
+		assert.Equal(t, i+1, t1.Redelivered)
+	}
+	err = handler(ctx, task.Redelivered, t1)
+	assert.NoError(t, err)
+	assert.Equal(t, tork.TaskStateFailed, t1.State)
+	assert.Equal(t, 5, t1.Redelivered)
+	assert.NotNil(t, t1.FailedAt)
+	assert.Equal(t, "task redelivered too many times", t1.Error)
+	assert.NoError(t, ds.Close())
+}

--- a/middleware/task/task.go
+++ b/middleware/task/task.go
@@ -16,6 +16,8 @@ const (
 	// Handler can inspect the task's State property
 	// in order to determine what state the task is at.
 	StateChange = "STATE_CHANGE"
+	// Redelivered event occurs when a task is redelivered.
+	Redelivered = "REDELIVERED"
 	// Progress event occurs when a task's progress changes.
 	Progress = "PROGRESS"
 	// Read occurs when a task is read by the client

--- a/task.go
+++ b/task.go
@@ -52,6 +52,7 @@ type Task struct {
 	Env         map[string]string `json:"env,omitempty"`
 	Files       map[string]string `json:"files,omitempty"`
 	Queue       string            `json:"queue,omitempty"`
+	Redelivered int               `json:"redelivered,omitempty"`
 	Error       string            `json:"error,omitempty"`
 	Pre         []*Task           `json:"pre,omitempty"`
 	Post        []*Task           `json:"post,omitempty"`


### PR DESCRIPTION
This PR adds support for tracking task redeliveries (due to worker disconnection) capped to a maximum of 5.

The goal is to protect worker nodes from "poison tasks" where tasks are repeatedly causing a node to crash, at which point the message gets requeued and the cycle starts again. 

The implementation includes:
1. Adding a new Coordinator-managed `redeliveries` queue to which all redelivered tasks are sent to.
2. Adding an ephemeral `redeliveries` field to the `Task` struct. 
3. A new `redelivery` Coordinator handler which increments the task's `redeliveries` field and either resubmits it to the original queue, or to the `errors` queue when `redeliveries` threshold is met. 