### PR TITLE
fix: omit network alias for podman host network

### DIFF
--- a/runtime/podman/podman.go
+++ b/runtime/podman/podman.go
@@ -224,7 +224,11 @@ func (d *PodmanRuntime) doRun(ctx context.Context, t *tork.Task, logger io.Write
 
 	// add networks to the container
 	for _, network := range t.Networks {
-		createCmd.Args = append(createCmd.Args, "--network", network, "--network-alias", slug.Make(t.Name))
+		createCmd.Args = append(createCmd.Args, "--network", network)
+		// network aliases are not supported with host networking
+		if network != "host" {
+			createCmd.Args = append(createCmd.Args, "--network-alias", slug.Make(t.Name))
+		}
 	}
 
 	// add mounts to the container


### PR DESCRIPTION
#### Enabling host network usage in the podman worker runtime (Option 1 of 2)

This change handles the special case where "host" is selected as a container network. This is a reserved word in podman networks since it's the name of a network mode. This network configuration can be useful in cases of multi-NIC access, high-performance networking, and service discovery.

Before this change, host networking was not being explicitly denied, but it did not work because of an extra flag, `--network-alias` being passed in that isn't compatible with the host network mode.

#### My take

Though this is the "simpler" change, I believe this decreases the overall security posture of the default podman tork worker implementation.