### PR TITLE
Fix: sidecar probing issues

### DIFF
--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -147,16 +147,11 @@ func (rt *DockerRuntime) Run(ctx context.Context, t *tork.Task) error {
 	}()
 
 	// if the tasks has sidecars, we need to create a network
-	var networkID string
 	if len(t.Sidecars) > 0 {
-		networkCreateResp, err := rt.client.NetworkCreate(ctx, uuid.NewUUID(), types.NetworkCreate{
-			CheckDuplicate: true,
-			Driver:         "bridge",
-		})
+		networkID, err := rt.createNetwork(context.Background())
 		if err != nil {
 			return errors.Wrapf(err, "error creating network")
 		}
-		networkID = networkCreateResp.ID
 		log.Debug().Msgf("Created network with ID %s", networkID)
 		t.Networks = append(t.Networks, networkID)
 		defer rt.removeNetwork(context.Background(), networkID)
@@ -272,10 +267,25 @@ func (rt *DockerRuntime) HealthCheck(ctx context.Context) error {
 	return err
 }
 
+func (rt *DockerRuntime) createNetwork(ctx context.Context) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	defer cancel()
+	networkCreateResp, err := rt.client.NetworkCreate(ctx, uuid.NewUUID(), types.NetworkCreate{
+		CheckDuplicate: true,
+		Driver:         "bridge",
+	})
+	if err != nil {
+		return "", errors.Wrapf(err, "error creating network")
+	}
+	return networkCreateResp.ID, nil
+}
+
 // removeNetwork attempts to remove a network with retry logic.
 // Docker cannot remove a network if containers are still connected to it,
 // so we retry with a small delay to ensure containers are fully removed first.
 func (rt *DockerRuntime) removeNetwork(ctx context.Context, networkID string) {
+	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	defer cancel()
 	log.Debug().Msgf("Removing network with ID %s", networkID)
 	maxRetries := 5
 	// 200ms, 400ms, 800ms, 1600ms, 3200ms

--- a/runtime/docker/tcontainer.go
+++ b/runtime/docker/tcontainer.go
@@ -346,6 +346,11 @@ func (tc *tcontainer) probeContainer(ctx context.Context) error {
 	if err != nil {
 		return errors.Wrapf(err, "error inspecting container %s", tc.id)
 	}
+	ports := insp.NetworkSettings.Ports[nat.Port(fmt.Sprintf("%d/tcp", tc.task.Probe.Port))]
+	if len(ports) == 0 {
+		return errors.Errorf("no port found for container %s", tc.id)
+	}
+
 	portStr := insp.NetworkSettings.Ports[nat.Port(fmt.Sprintf("%d/tcp", tc.task.Probe.Port))][0].HostPort
 	portNum, err := strconv.Atoi(portStr)
 	if err != nil {
@@ -367,13 +372,40 @@ func (tc *tcontainer) probeContainer(ctx context.Context) error {
 		return errors.Wrapf(err, "error parsing probe timeout %s", tc.task.Probe.Timeout)
 	}
 
+	// read the container's stdout
+	out, err := tc.client.ContainerLogs(
+		ctx,
+		tc.id,
+		container.LogsOptions{
+			ShowStdout: true,
+			ShowStderr: true,
+			Follow:     true,
+		},
+	)
+	if err != nil {
+		return errors.Wrapf(err, "error getting logs for container %s: %v\n", tc.id, err)
+	}
+	// close the stdout reader
+	defer func() {
+		if err := out.Close(); err != nil {
+			log.Error().Err(err).Msgf("error closing stdout on container %s", tc.id)
+		}
+	}()
+	// copy the container's stdout to the logger
+	go func() {
+		_, err = io.Copy(tc.logger, dockerLogsReader{reader: out})
+		if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, context.Canceled) {
+			log.Error().Err(err).Msgf("error reading the std out")
+		}
+	}()
+
 	probeCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	for {
 		select {
 		case <-probeCtx.Done():
-			return errors.New("probe timed out after 1 minute")
+			return errors.Errorf("probe timed out after %s", tc.task.Probe.Timeout)
 		case <-time.After(time.Second):
 			req, err := http.NewRequestWithContext(probeCtx, http.MethodGet, probeURL, nil)
 			if err != nil {


### PR DESCRIPTION
## Summary
This PR fixes network creation by using a background context with a timeout instead of the task context, which could be cancelled prematurely.

## Changes

`runtime/docker/docker.go`
* Extracted network creation into `createNetwork()` that uses `context.Background()` with a 10-second timeout
Added a 10-second timeout to `removeNetwork()` for consistency

`runtime/docker/tcontainer.go`
* Added port validation in `probeContainer()` to check ports exist before access
* Added container log streaming during probe execution
* Improved probe timeout error message to show the actual timeout duration