### PR TITLE
feat: add bind mount option support to docker and podman runtimes

### DIFF
--- a/input/validate.go
+++ b/input/validate.go
@@ -76,6 +76,8 @@ func validateMount(sl validator.StructLevel) {
 		sl.ReportError(mnt, "mount", "Mount", "invalidtarget", "")
 	} else if mnt.Target == "/tork" {
 		sl.ReportError(mnt, "mount", "Mount", "invalidtarget", "")
+	} else if err := tork.ValidateMountOpts(mnt.toMount()); err != nil {
+		sl.ReportError(mnt, "mount", "Mount", "invalidopts", "")
 	}
 }
 

--- a/input/validate_test.go
+++ b/input/validate_test.go
@@ -660,6 +660,110 @@ func TestValidateMounts(t *testing.T) {
 	}
 	err = j.Validate(ds)
 	assert.NoError(t, err)
+
+	j = Job{
+		Name: "test job",
+		Tasks: []Task{
+			{
+				Name:  "test task",
+				Image: "some:image",
+				Run:   "some script",
+				Mounts: []Mount{
+					{
+						Type:   tork.MountTypeBind,
+						Source: "/some/source",
+						Target: "/some/target",
+						Opts:   map[string]string{"propagation": "rslave"},
+					},
+				},
+			},
+		},
+	}
+	err = j.Validate(ds)
+	assert.NoError(t, err)
+
+	j = Job{
+		Name: "test job",
+		Tasks: []Task{
+			{
+				Name:  "test task",
+				Image: "some:image",
+				Run:   "some script",
+				Mounts: []Mount{
+					{
+						Type:   tork.MountTypeBind,
+						Source: "/some/source",
+						Target: "/some/target",
+						Opts:   map[string]string{"propagation": "rshared"},
+					},
+				},
+			},
+		},
+	}
+	err = j.Validate(ds)
+	assert.Error(t, err)
+
+	j = Job{
+		Name: "test job",
+		Tasks: []Task{
+			{
+				Name:  "test task",
+				Image: "some:image",
+				Run:   "some script",
+				Mounts: []Mount{
+					{
+						Type:   tork.MountTypeBind,
+						Source: "/some/source",
+						Target: "/some/target",
+						Opts:   map[string]string{"propogation": "rslave"},
+					},
+				},
+			},
+		},
+	}
+	err = j.Validate(ds)
+	assert.Error(t, err)
+
+	j = Job{
+		Name: "test job",
+		Tasks: []Task{
+			{
+				Name:  "test task",
+				Image: "some:image",
+				Run:   "some script",
+				Mounts: []Mount{
+					{
+						Type:   tork.MountTypeBind,
+						Source: "/some/source",
+						Target: "/some/target",
+						Opts:   map[string]string{"readonly": "true"},
+					},
+				},
+			},
+		},
+	}
+	err = j.Validate(ds)
+	assert.NoError(t, err)
+
+	j = Job{
+		Name: "test job",
+		Tasks: []Task{
+			{
+				Name:  "test task",
+				Image: "some:image",
+				Run:   "some script",
+				Mounts: []Mount{
+					{
+						Type:   tork.MountTypeVolume,
+						Target: "/some/target",
+						Opts:   map[string]string{"driver_opt_1": "value"},
+					},
+				},
+			},
+		},
+	}
+	err = j.Validate(ds)
+	assert.NoError(t, err)
 	assert.NoError(t, ds.Close())
 }
 

--- a/mount.go
+++ b/mount.go
@@ -1,12 +1,55 @@
 package tork
 
-import "golang.org/x/exp/maps"
+import (
+	"fmt"
+
+	"golang.org/x/exp/maps"
+)
 
 const (
 	MountTypeVolume string = "volume"
 	MountTypeBind   string = "bind"
 	MountTypeTmpfs  string = "tmpfs"
 )
+
+var allowedPropagation = map[string]bool{
+	"private":  true,
+	"rprivate": true,
+	"slave":    true,
+	"rslave":   true,
+}
+
+var allowedBindOpts = map[string]bool{
+	"propagation": true,
+	"readonly":    true,
+}
+
+var allowedTmpfsOpts = map[string]bool{
+	"readonly": true,
+}
+
+func ValidateMountOpts(m *Mount) error {
+	var allowed map[string]bool
+	switch m.Type {
+	case MountTypeBind:
+		allowed = allowedBindOpts
+	case MountTypeTmpfs:
+		allowed = allowedTmpfsOpts
+	default:
+		return nil
+	}
+	for key := range m.Opts {
+		if !allowed[key] {
+			return fmt.Errorf("unsupported option %q for %s mount", key, m.Type)
+		}
+	}
+	if prop, ok := m.Opts["propagation"]; ok {
+		if !allowedPropagation[prop] {
+			return fmt.Errorf("unsupported mount propagation: %s", prop)
+		}
+	}
+	return nil
+}
 
 type Mount struct {
 	ID     string            `json:"-"`

--- a/mount_test.go
+++ b/mount_test.go
@@ -1,0 +1,66 @@
+package tork
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateMountOpts(t *testing.T) {
+	tests := []struct {
+		name    string
+		mount   *Mount
+		wantErr bool
+	}{
+		{
+			name:    "bind mount with valid propagation",
+			mount:   &Mount{Type: MountTypeBind, Opts: map[string]string{"propagation": "rslave"}},
+			wantErr: false,
+		},
+		{
+			name:    "bind mount with invalid propagation",
+			mount:   &Mount{Type: MountTypeBind, Opts: map[string]string{"propagation": "rshared"}},
+			wantErr: true,
+		},
+		{
+			name:    "bind mount with readonly",
+			mount:   &Mount{Type: MountTypeBind, Opts: map[string]string{"readonly": "true"}},
+			wantErr: false,
+		},
+		{
+			name:    "bind mount with unknown key",
+			mount:   &Mount{Type: MountTypeBind, Opts: map[string]string{"propogation": "rslave"}},
+			wantErr: true,
+		},
+		{
+			name:    "tmpfs mount with readonly",
+			mount:   &Mount{Type: MountTypeTmpfs, Opts: map[string]string{"readonly": "true"}},
+			wantErr: false,
+		},
+		{
+			name:    "tmpfs mount with unknown key",
+			mount:   &Mount{Type: MountTypeTmpfs, Opts: map[string]string{"size": "64m"}},
+			wantErr: true,
+		},
+		{
+			name:    "volume mount allows arbitrary keys",
+			mount:   &Mount{Type: MountTypeVolume, Opts: map[string]string{"driver_opt": "value"}},
+			wantErr: false,
+		},
+		{
+			name:    "bind mount with no opts",
+			mount:   &Mount{Type: MountTypeBind, Opts: nil},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateMountOpts(tt.mount)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/runtime/docker/docker_test.go
+++ b/runtime/docker/docker_test.go
@@ -348,6 +348,31 @@ func TestRunTaskWithBind(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestRunTaskWithBindAndPropagation(t *testing.T) {
+	mm := runtime.NewMultiMounter()
+	vm, err := NewVolumeMounter()
+	assert.NoError(t, err)
+	mm.RegisterMounter("bind", NewBindMounter(BindConfig{Allowed: true}))
+	mm.RegisterMounter("volume", vm)
+	rt, err := NewDockerRuntime(WithMounter(mm))
+	assert.NoError(t, err)
+	ctx := context.Background()
+	dir := path.Join(os.TempDir(), uuid.NewUUID())
+	t1 := &tork.Task{
+		ID:    uuid.NewUUID(),
+		Image: "busybox:stable",
+		Run:   "echo hello world > /xyz/thing",
+		Mounts: []*tork.Mount{{
+			Type:   tork.MountTypeBind,
+			Target: "/xyz",
+			Source: dir,
+			Opts:   map[string]string{"propagation": "rslave"},
+		}},
+	}
+	err = rt.Run(ctx, t1)
+	assert.NoError(t, err)
+}
+
 func TestRunTaskWithTempfs(t *testing.T) {
 	rt, err := NewDockerRuntime(
 		WithMounter(NewTmpfsMounter()),

--- a/runtime/docker/tcontainer.go
+++ b/runtime/docker/tcontainer.go
@@ -77,13 +77,21 @@ func createTaskContainer(ctx context.Context, rt *DockerRuntime, t *tork.Task, l
 		default:
 			return nil, errors.Errorf("unknown mount type: %s", m.Type)
 		}
-		mount := mount.Mount{
-			Type:   mt,
-			Source: m.Source,
-			Target: m.Target,
+		mn := mount.Mount{
+			Type:     mt,
+			Source:   m.Source,
+			Target:   m.Target,
+			ReadOnly: m.Opts["readonly"] == "true",
 		}
-		log.Debug().Msgf("Mounting %s -> %s", mount.Source, mount.Target)
-		mounts = append(mounts, mount)
+		if mt == mount.TypeBind {
+			if prop, ok := m.Opts["propagation"]; ok {
+				mn.BindOptions = &mount.BindOptions{
+					Propagation: mount.Propagation(prop),
+				}
+			}
+		}
+		log.Debug().Msgf("Mounting %s -> %s", mn.Source, mn.Target)
+		mounts = append(mounts, mn)
 	}
 
 	torkdir := &tork.Mount{

--- a/runtime/podman/podman.go
+++ b/runtime/podman/podman.go
@@ -247,10 +247,8 @@ func (d *PodmanRuntime) doRun(ctx context.Context, t *tork.Task, logger io.Write
 	// add mounts to the container
 	for _, mount := range t.Mounts {
 		switch mount.Type {
-		case tork.MountTypeVolume:
-			createCmd.Args = append(createCmd.Args, "-v", fmt.Sprintf("%s:%s", mount.Source, mount.Target))
-		case tork.MountTypeBind:
-			createCmd.Args = append(createCmd.Args, "-v", fmt.Sprintf("%s:%s", mount.Source, mount.Target))
+		case tork.MountTypeVolume, tork.MountTypeBind:
+			createCmd.Args = append(createCmd.Args, "-v", formatVolumeSpec(mount))
 		default:
 			return fmt.Errorf("unknown mount type: %s", mount.Type)
 		}
@@ -381,6 +379,21 @@ func (d *PodmanRuntime) stop(ctx context.Context, t *tork.Task) error {
 		return fmt.Errorf("failed to stop container %s: %w", containerID, err)
 	}
 	return nil
+}
+
+func formatVolumeSpec(m *tork.Mount) string {
+	spec := fmt.Sprintf("%s:%s", m.Source, m.Target)
+	var opts []string
+	if m.Opts["readonly"] == "true" {
+		opts = append(opts, "ro")
+	}
+	if prop, ok := m.Opts["propagation"]; ok {
+		opts = append(opts, prop)
+	}
+	if len(opts) > 0 {
+		spec += ":" + strings.Join(opts, ",")
+	}
+	return spec
 }
 
 func (d *PodmanRuntime) HealthCheck(ctx context.Context) error {

--- a/runtime/podman/podman.go
+++ b/runtime/podman/podman.go
@@ -247,7 +247,9 @@ func (d *PodmanRuntime) doRun(ctx context.Context, t *tork.Task, logger io.Write
 	// add mounts to the container
 	for _, mount := range t.Mounts {
 		switch mount.Type {
-		case tork.MountTypeVolume, tork.MountTypeBind:
+		case tork.MountTypeVolume:
+			createCmd.Args = append(createCmd.Args, "-v", fmt.Sprintf("%s:%s", mount.Source, mount.Target))
+		case tork.MountTypeBind:
 			createCmd.Args = append(createCmd.Args, "-v", formatVolumeSpec(mount))
 		default:
 			return fmt.Errorf("unknown mount type: %s", mount.Type)

--- a/runtime/podman/podman_test.go
+++ b/runtime/podman/podman_test.go
@@ -407,6 +407,37 @@ func TestRunTaskWithCustomMounter(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestFormatVolumeSpec(t *testing.T) {
+	assert.Equal(t, "/src:/dst", formatVolumeSpec(&tork.Mount{Source: "/src", Target: "/dst"}))
+	assert.Equal(t, "/src:/dst:rslave", formatVolumeSpec(&tork.Mount{Source: "/src", Target: "/dst", Opts: map[string]string{"propagation": "rslave"}}))
+	assert.Equal(t, "/src:/dst:ro", formatVolumeSpec(&tork.Mount{Source: "/src", Target: "/dst", Opts: map[string]string{"readonly": "true"}}))
+	assert.Equal(t, "/src:/dst:ro,rslave", formatVolumeSpec(&tork.Mount{Source: "/src", Target: "/dst", Opts: map[string]string{"readonly": "true", "propagation": "rslave"}}))
+}
+
+func TestPodmanRunTaskWithBindAndPropagation(t *testing.T) {
+	mm := runtime.NewMultiMounter()
+	vm := NewVolumeMounter()
+	mm.RegisterMounter("bind", docker.NewBindMounter(docker.BindConfig{Allowed: true}))
+	mm.RegisterMounter("volume", vm)
+	rt := NewPodmanRuntime(WithMounter(mm))
+	ctx := context.Background()
+	dir := path.Join(os.TempDir(), uuid.NewUUID())
+	t1 := &tork.Task{
+		ID:    uuid.NewUUID(),
+		Name:  "Some task",
+		Image: "busybox:stable",
+		Run:   "echo hello world > /xyz/thing",
+		Mounts: []*tork.Mount{{
+			Type:   tork.MountTypeBind,
+			Target: "/xyz",
+			Source: dir,
+			Opts:   map[string]string{"propagation": "rslave"},
+		}},
+	}
+	err := rt.Run(ctx, t1)
+	assert.NoError(t, err)
+}
+
 func Test_imagePull(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
## Support bind mount options (propagation, readonly) in Docker and Podman runtimes

### Problem

  The Mount struct has an Opts field, but neither the Docker nor Podman runtimes pass these options through when creating containers. This means bind mount propagation is always the runtime default (rprivate),
  which prevents containers from seeing mounts that appear on the host after container creation (e.g. when using autofs). Containers are also unable to bind mounts as read-only, which can be a useful security
  control.

### Changes

**Runtime support**

Both runtimes now read two options from `Mount.Opts` for bind mounts:
  * `propagation` — mount propagation mode (e.g. rslave, rprivate)
  * `readonly` — when set to "true", mounts the volume read-only

Podman (`runtime/podman/podman.go`): Extracted a `formatVolumeSpec` helper that appends options to the `-v` spec string (e.g. `/src:/dst:ro,rslave`).
Docker (`runtime/docker/tcontainer.go`): Sets `BindOptions.Propagation` and `ReadOnly` on the SDK `mount.Mount` struct when the corresponding opts are present.

**Input validation**

  * Bind mounts only accept `propagation` and `readonly` as option keys — unknown keys are rejected to catch typos and prevent silent misconfiguration.
  * Tmpfs mounts only accept `readonly`.
  * Volume mounts pass opts through unrestricted (they go to the Docker volume driver).
  * Propagation values are restricted to `private`, `rprivate`, `slave`, and `rslave`. Shared/rshared modes are disallowed to prevent containers from mutating the host's mount table.
  * Podman volume mounts skip option parsing entirely (opts are driver-level, not mount-level).

No changes to the Mount struct or task input schema.

### Usage

```yaml
  mounts:
    - type: bind
      source: /mnt
      target: /mnt
      opts:
        propagation: rslave
        readonly: "true"
```

Tasks without mount opts are unaffected.

### Tests

  * `TestFormatVolumeSpec`: unit tests for the podman volume spec builder
  * `TestPodmanRunTaskWithBindAndPropagation`: integration test with podman
  * `TestRunTaskWithBindAndPropagation`: integration test with Docker
  * `TestValidateMountOpts`: unit tests for opts key/value validation across mount types
  * `TestValidateMounts`: integration test cases for invalid keys and valid readonly