### PR TITLE
Fix var redact

### DIFF
--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -136,16 +136,24 @@ func (r *Redacter) RedactJob(j *tork.Job) {
 func (r *Redacter) redactVars(m map[string]string, secrets map[string]string) map[string]string {
 	redacted := make(map[string]string)
 	for k, v := range m {
-		for _, m := range r.matchers {
-			if m(k) {
-				v = redactedStr
-				break
-			}
-		}
-		for _, secret := range secrets {
-			v = strings.ReplaceAll(v, secret, redactedStr)
-		}
-		redacted[k] = v
+		redacted[k] = r.redactVar(k, v, secrets)
 	}
 	return redacted
+}
+
+func (r *Redacter) redactVar(k, v string, secrets map[string]string) string {
+	for _, m := range r.matchers {
+		if m(k) {
+			return redactedStr
+		}
+	}
+	for _, secret := range secrets {
+		if secret == "" {
+			continue
+		}
+		if strings.Contains(v, secret) {
+			return redactedStr
+		}
+	}
+	return v
 }

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -91,7 +91,7 @@ func TestRedactTask(t *testing.T) {
 
 	assert.Equal(t, "[REDACTED]", ta.Env["secret_1"])
 	assert.Equal(t, "[REDACTED]", ta.Env["SecrET_2"])
-	assert.Equal(t, "some [REDACTED]", ta.Env["something_3"])
+	assert.Equal(t, "[REDACTED]", ta.Env["something_3"])
 	assert.Equal(t, "[REDACTED]", ta.Env["PASSword"])
 	assert.Equal(t, "hello world", ta.Env["harmless"])
 	assert.Equal(t, "[REDACTED]", ta.Env["AWS_ACCESS_KEY_ID"])
@@ -105,7 +105,7 @@ func TestRedactTask(t *testing.T) {
 	assert.Equal(t, "[REDACTED]", ta.Registry.Password)
 	assert.Equal(t, "[REDACTED]", ta.Env["thing"])
 	assert.Equal(t, "[REDACTED]", ta.SubJob.Secrets["hush"])
-	assert.Equal(t, "bearer [REDACTED]", ta.SubJob.Webhooks[0].Headers["token"])
+	assert.Equal(t, "[REDACTED]", ta.SubJob.Webhooks[0].Headers["token"])
 	assert.Equal(t, "[REDACTED]", ta.Mounts[0].Opts["secret"])
 	assert.NoError(t, ds.Close())
 }
@@ -242,5 +242,26 @@ func TestRedactJobWildcard(t *testing.T) {
 	assert.Equal(t, "secret", j.Tasks[0].Env["_secret_2"])
 	assert.Equal(t, "password", j.Tasks[0].Env["PASSword"])
 	assert.Equal(t, "hello world", j.Tasks[0].Env["harmless"])
+	assert.NoError(t, ds.Close())
+}
+
+func Test_redactVars(t *testing.T) {
+	ds, err := postgres.NewTestDatastore()
+	assert.NoError(t, err)
+	redacter := NewRedacter(ds)
+	redacted := redacter.redactVars(map[string]string{
+		"secret":    "secret",
+		"something": "else",
+		"lots_of_a": "aaaaaa",
+	}, map[string]string{
+		"secret": "secret",
+		"empty":  "",
+		"a":      "a",
+		"tab":    "\t",
+		"space":  " ",
+	})
+	assert.Equal(t, "[REDACTED]", redacted["secret"])
+	assert.Equal(t, "else", redacted["something"])
+	assert.Equal(t, "[REDACTED]", redacted["lots_of_a"])
 	assert.NoError(t, ds.Close())
 }


### PR DESCRIPTION
Fixes a criticial performance bug in var redaction when a job secret value is empty. `strings.ReplaceAll(v, "", …)` matches at every position and can blow up CPU and memory on long strings.