### PR TITLE
Fix redact logs

### DIFF
--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -61,6 +61,9 @@ func (r *Redacter) RedactTask(t *tork.Task) {
 func (r *Redacter) RedactTaskLogPart(p *tork.TaskLogPart, secrets map[string]string) {
 	contents := p.Contents
 	for _, secret := range secrets {
+		if strings.TrimSpace(secret) == "" {
+			continue
+		}
 		contents = strings.ReplaceAll(contents, secret, redactedStr)
 	}
 	p.Contents = contents
@@ -148,7 +151,7 @@ func (r *Redacter) redactVar(k, v string, secrets map[string]string) string {
 		}
 	}
 	for _, secret := range secrets {
-		if secret == "" {
+		if strings.TrimSpace(secret) == "" {
 			continue
 		}
 		if strings.Contains(v, secret) {

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -265,3 +265,21 @@ func Test_redactVars(t *testing.T) {
 	assert.Equal(t, "[REDACTED]", redacted["lots_of_a"])
 	assert.NoError(t, ds.Close())
 }
+
+func TestRedactTaskLogPart(t *testing.T) {
+	ds, err := postgres.NewTestDatastore()
+	assert.NoError(t, err)
+	redacter := NewRedacter(ds)
+	p := &tork.TaskLogPart{
+		Contents: "line 1 -- 1234 -- a -- \t --  ",
+	}
+	redacter.RedactTaskLogPart(p, map[string]string{
+		"secret": "1234",
+		"empty":  "",
+		"a":      "a",
+		"tab":    "\t",
+		"space":  " ",
+	})
+	assert.Equal(t, "line 1 -- [REDACTED] -- [REDACTED] -- \t --  ", p.Contents)
+	assert.NoError(t, ds.Close())
+}


### PR DESCRIPTION
Fixes a criticial performance bug in log redaction when a job's secret value is empty. `strings.ReplaceAll(v, "", …)` matches at every position and can blow up CPU and memory on long strings.