### PR TITLE
Fix: task log part too long error

### DIFF
--- a/broker/log.go
+++ b/broker/log.go
@@ -8,6 +8,9 @@ import (
 	"github.com/runabol/tork"
 )
 
+// maxLogPartSize keeps each log part under PostgreSQL's tsvector input limit (~1 MiB).
+const maxLogPartSize = 512 * 1024
+
 type LogShipper struct {
 	Broker Broker
 	TaskID string
@@ -39,18 +42,29 @@ func (r *LogShipper) startFlushTimer() {
 		select {
 		case p := <-r.q:
 			buffer = append(buffer, p...)
-		case <-ticker.C:
-			if len(buffer) > 0 {
-				r.part = r.part + 1
-				if err := r.Broker.PublishTaskLogPart(context.Background(), &tork.TaskLogPart{
-					Number:   r.part,
-					TaskID:   r.TaskID,
-					Contents: string(buffer),
-				}); err != nil {
-					log.Error().Err(err).Msgf("error forwarding task log part")
-				}
-				buffer = buffer[:0] // clear buffer
+			if len(buffer) >= maxLogPartSize {
+				r.flush(&buffer)
 			}
+		case <-ticker.C:
+			r.flush(&buffer)
 		}
+	}
+}
+
+func (r *LogShipper) flush(buffer *[]byte) {
+	for len(*buffer) > 0 {
+		n := len(*buffer)
+		if n > maxLogPartSize {
+			n = maxLogPartSize
+		}
+		r.part++
+		if err := r.Broker.PublishTaskLogPart(context.Background(), &tork.TaskLogPart{
+			Number:   r.part,
+			TaskID:   r.TaskID,
+			Contents: string((*buffer)[:n]),
+		}); err != nil {
+			log.Error().Err(err).Msgf("error forwarding task log part")
+		}
+		*buffer = (*buffer)[n:]
 	}
 }

--- a/broker/log_test.go
+++ b/broker/log_test.go
@@ -61,3 +61,35 @@ func TestLogShipperWriteBufferFull(t *testing.T) {
 		assert.NoError(t, err)
 	}
 }
+
+func TestLogShipperSplitsLargeBuffer(t *testing.T) {
+	b := NewInMemoryBroker()
+
+	parts := make(chan string, 2)
+	err := b.SubscribeForTaskLogPart(func(p *tork.TaskLogPart) {
+		parts <- p.Contents
+	})
+	assert.NoError(t, err)
+
+	fwd := NewLogShipper(b, "some-task-id")
+	payload := make([]byte, maxLogPartSize+1000)
+	for i := range payload {
+		payload[i] = 'x'
+	}
+	_, err = fwd.Write(payload)
+	assert.NoError(t, err)
+
+	received := make([]string, 0, 2)
+	for i := 0; i < 2; i++ {
+		select {
+		case part := <-parts:
+			received = append(received, part)
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timed out waiting for log part %d", i+1)
+		}
+	}
+
+	assert.Len(t, received, 2)
+	assert.Len(t, received[0], maxLogPartSize)
+	assert.Len(t, received[1], 1000)
+}

--- a/datastore/postgres/postgres_test.go
+++ b/datastore/postgres/postgres_test.go
@@ -1120,6 +1120,36 @@ func TestPostgresQueryTaskLogs(t *testing.T) {
 	assert.Equal(t, "line 91", logs.Items[0].Contents)
 }
 
+func TestPostgresCreateLargeTaskLogPart(t *testing.T) {
+	ctx := context.Background()
+	ds, err := NewTestDatastore()
+	assert.NoError(t, err)
+	now := time.Now().UTC()
+	j1 := tork.Job{ID: uuid.NewUUID()}
+	err = ds.CreateJob(ctx, &j1)
+	assert.NoError(t, err)
+	t1 := tork.Task{
+		ID:        uuid.NewUUID(),
+		CreatedAt: &now,
+		JobID:     j1.ID,
+	}
+	err = ds.CreateTask(ctx, &t1)
+	assert.NoError(t, err)
+
+	contents := strings.Repeat("x", 1301604)
+	err = ds.CreateTaskLogPart(ctx, &tork.TaskLogPart{
+		Number:   1,
+		TaskID:   t1.ID,
+		Contents: contents,
+	})
+	assert.NoError(t, err)
+
+	logs, err := ds.GetTaskLogParts(ctx, t1.ID, "", 1, 10)
+	assert.NoError(t, err)
+	assert.Len(t, logs.Items, 1)
+	assert.Equal(t, contents, logs.Items[0].Contents)
+}
+
 func TestPostgresCreateAndExpungeTaskLogs(t *testing.T) {
 	ctx := context.Background()
 	dsn := "host=localhost user=tork password=tork dbname=tork port=5432 sslmode=disable"

--- a/db/postgres/schema.go
+++ b/db/postgres/schema.go
@@ -186,7 +186,7 @@ CREATE TABLE tasks_log_parts (
 
 ALTER TABLE tasks_log_parts ADD COLUMN ts tsvector NOT NULL
     GENERATED ALWAYS AS (
-        to_tsvector('english',contents)  
+        to_tsvector('english', left(contents, 1048575))
     ) STORED;
 
 CREATE INDEX tasks_log_parts_ts_idx ON tasks_log_parts USING GIN (ts);


### PR DESCRIPTION
Fix task log insert failures when a single log part exceeds PostgreSQL's ~1 MiB tsvector input limit (pq: string is too long for tsvector).

* Truncate the generated `ts` column to the first 1,048,575 bytes via `left(contents, 1048575)`, so full log text is still stored while full-text indexing stays within PostgreSQL limits.
* Split `LogShipper` output into 512 KiB parts so high-volume tasks don't accumulate oversized log parts before flush.
* Add tests covering large log part inserts and multi-part log shipping.
