### PR TITLE
Feature: redact exclusions

### DIFF
--- a/configs/sample.config.toml
+++ b/configs/sample.config.toml
@@ -89,6 +89,8 @@ skip = ["GET /health"] # supports wildcards (*)
 
 [middleware.job.redact]
 enabled = false
+# patterns = ["*SECRET*"]       # key patterns to redact (wildcards supported)
+# exclude.patterns = ["*_PUBLIC"] # key patterns to skip redacting
 
 [middleware.task.hostenv]
 vars = [

--- a/engine/coordinator.go
+++ b/engine/coordinator.go
@@ -55,10 +55,15 @@ func (e *Engine) initCoordinator() error {
 		for i, pattern := range patterns {
 			matchers[i] = redact.Wildcard(pattern)
 		}
-		redacter := redact.NewRedacter(e.datastoreRef, matchers...)
+		excludePatterns := conf.Strings("middleware.job.redact.exclude.patterns")
+		exclusions := make([]redact.Matcher, len(excludePatterns))
+		for i, pattern := range excludePatterns {
+			exclusions[i] = redact.Wildcard(pattern)
+		}
+		redacter := redact.NewRedacterWithMatchers(e.datastoreRef, exclusions, matchers...)
 		cfg.Middleware.Job = append(cfg.Middleware.Job, job.Redact(redacter))
 		cfg.Middleware.Task = append(cfg.Middleware.Task, task.Redact(redacter))
-		cfg.Middleware.Log = append(cfg.Middleware.Log, logmw.Redact(e.datastoreRef))
+		cfg.Middleware.Log = append(cfg.Middleware.Log, logmw.Redact(redacter))
 	}
 
 	// webhook middleware

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -2,6 +2,7 @@ package redact
 
 import (
 	"context"
+	"maps"
 	"strings"
 
 	"github.com/rs/zerolog/log"
@@ -15,17 +16,23 @@ const (
 )
 
 type Redacter struct {
-	matchers []Matcher
-	ds       datastore.Datastore
+	matchers   []Matcher
+	exclusions []Matcher
+	ds         datastore.Datastore
 }
 
-func NewRedacter(ds datastore.Datastore, matchers ...Matcher) *Redacter {
+func NewRedacter(ds datastore.Datastore) *Redacter {
+	return NewRedacterWithMatchers(ds, nil)
+}
+
+func NewRedacterWithMatchers(ds datastore.Datastore, exclusions []Matcher, matchers ...Matcher) *Redacter {
 	if len(matchers) == 0 {
 		matchers = defaultMatchers
 	}
 	return &Redacter{
-		matchers: matchers,
-		ds:       ds,
+		matchers:   matchers,
+		exclusions: exclusions,
+		ds:         ds,
 	}
 }
 
@@ -60,7 +67,10 @@ func (r *Redacter) RedactTask(t *tork.Task) {
 
 func (r *Redacter) RedactTaskLogPart(p *tork.TaskLogPart, secrets map[string]string) {
 	contents := p.Contents
-	for _, secret := range secrets {
+	for name, secret := range secrets {
+		if r.isExcluded(name) {
+			continue
+		}
 		if strings.TrimSpace(secret) == "" {
 			continue
 		}
@@ -72,6 +82,26 @@ func (r *Redacter) RedactTaskLogPart(p *tork.TaskLogPart, secrets map[string]str
 		contents = strings.ReplaceAll(contents, secret, redactedStr)
 	}
 	p.Contents = contents
+}
+
+func (r *Redacter) RedactTaskLogParts(ctx context.Context, parts []*tork.TaskLogPart) error {
+	if len(parts) == 0 {
+		return nil
+	}
+	task, err := r.ds.GetTaskByID(ctx, parts[0].TaskID)
+	if err != nil {
+		log.Error().Err(err).Msg("error getting task for log")
+		return err
+	}
+	job, err := r.ds.GetJobByID(ctx, task.JobID)
+	if err != nil {
+		log.Error().Err(err).Msg("error getting job for log")
+		return err
+	}
+	for _, p := range parts {
+		r.RedactTaskLogPart(p, job.Secrets)
+	}
+	return nil
 }
 
 func (r *Redacter) doRedactTask(t *tork.Task, secrets map[string]string) {
@@ -115,29 +145,29 @@ func (r *Redacter) doRedactTask(t *tork.Task, secrets map[string]string) {
 }
 
 func (r *Redacter) RedactJob(j *tork.Job) {
+	secrets := maps.Clone(j.Secrets)
 	redacted := j
 	// redact inputs
-	redacted.Inputs = r.redactVars(redacted.Inputs, j.Secrets)
+	redacted.Inputs = r.redactVars(redacted.Inputs, secrets)
+	// redact secrets
+	redacted.Secrets = r.redactVars(redacted.Secrets, secrets)
 	// redact webhook headers
 	for _, w := range j.Webhooks {
 		if w.Headers != nil {
-			w.Headers = r.redactVars(w.Headers, j.Secrets)
+			w.Headers = r.redactVars(w.Headers, secrets)
 		}
 	}
 	// redact context
-	redacted.Context.Inputs = r.redactVars(redacted.Context.Inputs, j.Secrets)
-	redacted.Context.Secrets = r.redactVars(redacted.Context.Secrets, j.Secrets)
-	redacted.Context.Tasks = r.redactVars(redacted.Context.Tasks, j.Secrets)
+	redacted.Context.Inputs = r.redactVars(redacted.Context.Inputs, secrets)
+	redacted.Context.Secrets = r.redactVars(redacted.Context.Secrets, secrets)
+	redacted.Context.Tasks = r.redactVars(redacted.Context.Tasks, secrets)
 	// redact tasks
 	for _, t := range redacted.Tasks {
-		r.doRedactTask(t, j.Secrets)
+		r.doRedactTask(t, secrets)
 	}
 	// redact execution
 	for _, t := range redacted.Execution {
-		r.doRedactTask(t, j.Secrets)
-	}
-	for k := range j.Secrets {
-		redacted.Secrets[k] = redactedStr
+		r.doRedactTask(t, secrets)
 	}
 }
 
@@ -150,12 +180,17 @@ func (r *Redacter) redactVars(m map[string]string, secrets map[string]string) ma
 }
 
 func (r *Redacter) redactVar(k, v string, secrets map[string]string) string {
-	for _, m := range r.matchers {
-		if m(k) {
-			return redactedStr
+	if !r.isExcluded(k) {
+		for _, m := range r.matchers {
+			if m(k) {
+				return redactedStr
+			}
 		}
 	}
-	for _, secret := range secrets {
+	for name, secret := range secrets {
+		if r.isExcluded(name) {
+			continue
+		}
 		if strings.TrimSpace(secret) == "" {
 			continue
 		}
@@ -164,4 +199,13 @@ func (r *Redacter) redactVar(k, v string, secrets map[string]string) string {
 		}
 	}
 	return v
+}
+
+func (r *Redacter) isExcluded(k string) bool {
+	for _, m := range r.exclusions {
+		if m(k) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -191,6 +191,28 @@ func TestRedactJob(t *testing.T) {
 	assert.Equal(t, "http://example.com/1", j.Webhooks[0].URL)
 	assert.Equal(t, "http://example.com/2", j.Webhooks[1].URL)
 	assert.Equal(t, map[string]string{"my-header": "my-value", "my-secret": "[REDACTED]", "another-header": "[REDACTED]"}, j.Webhooks[1].Headers)
+	assert.Equal(t, "[REDACTED]", j.Secrets["something"])
+}
+
+func TestRedactJobSecrets(t *testing.T) {
+	o := &tork.Job{
+		Secrets: map[string]string{
+			"db_password":   "secret123",
+			"token_public":  "public-token",
+			"config_path":   "/etc/app",
+		},
+	}
+	j := o.Clone()
+
+	ds, err := postgres.NewTestDatastore()
+	assert.NoError(t, err)
+	redacter := NewRedacterWithMatchers(ds, []Matcher{Wildcard("*_public")})
+	redacter.RedactJob(j)
+
+	assert.Equal(t, "[REDACTED]", j.Secrets["db_password"])
+	assert.Equal(t, "public-token", j.Secrets["token_public"])
+	assert.Equal(t, "[REDACTED]", j.Secrets["config_path"])
+	assert.NoError(t, ds.Close())
 }
 
 func TestRedactJobContains(t *testing.T) {
@@ -218,6 +240,59 @@ func TestRedactJobContains(t *testing.T) {
 	assert.NoError(t, ds.Close())
 }
 
+func TestRedactJobExclusions(t *testing.T) {
+	o := &tork.Job{
+		Tasks: []*tork.Task{
+			{
+				Env: map[string]string{
+					"secret_1":        "secret",
+					"secret_public":   "visible",
+					"PASSWORD":        "password",
+					"PASSWORD_public": "visible",
+				},
+			},
+		},
+	}
+	j := o.Clone()
+
+	ds, err := postgres.NewTestDatastore()
+	assert.NoError(t, err)
+	redacter := NewRedacterWithMatchers(ds, []Matcher{Wildcard("*_public")})
+	redacter.RedactJob(j)
+
+	assert.Equal(t, "[REDACTED]", j.Tasks[0].Env["secret_1"])
+	assert.Equal(t, "visible", j.Tasks[0].Env["secret_public"])
+	assert.Equal(t, "[REDACTED]", j.Tasks[0].Env["PASSWORD"])
+	assert.Equal(t, "visible", j.Tasks[0].Env["PASSWORD_public"])
+	assert.NoError(t, ds.Close())
+}
+
+func TestRedactJobExclusionsSkipExcludedSecretNames(t *testing.T) {
+	ds, err := postgres.NewTestDatastore()
+	assert.NoError(t, err)
+	redacter := NewRedacterWithMatchers(ds, []Matcher{Wildcard("*_public")})
+	redacted := redacter.redactVars(map[string]string{
+		"my_var": "shhhhh",
+	}, map[string]string{
+		"hush_public": "shhhhh",
+	})
+	assert.Equal(t, "shhhhh", redacted["my_var"])
+	assert.NoError(t, ds.Close())
+}
+
+func TestRedactJobExclusionsStillRedactNonExcludedSecretNames(t *testing.T) {
+	ds, err := postgres.NewTestDatastore()
+	assert.NoError(t, err)
+	redacter := NewRedacterWithMatchers(ds, []Matcher{Wildcard("*_public")})
+	redacted := redacter.redactVars(map[string]string{
+		"my_var": "shhhhh",
+	}, map[string]string{
+		"hush": "shhhhh",
+	})
+	assert.Equal(t, "[REDACTED]", redacted["my_var"])
+	assert.NoError(t, ds.Close())
+}
+
 func TestRedactJobWildcard(t *testing.T) {
 	o := &tork.Job{
 		Tasks: []*tork.Task{
@@ -235,7 +310,7 @@ func TestRedactJobWildcard(t *testing.T) {
 
 	ds, err := postgres.NewTestDatastore()
 	assert.NoError(t, err)
-	redacter := NewRedacter(ds, Wildcard("secret*"))
+	redacter := NewRedacterWithMatchers(ds, nil, Wildcard("secret*"))
 	redacter.RedactJob(j)
 
 	assert.Equal(t, "[REDACTED]", j.Tasks[0].Env["secret_1"])

--- a/middleware/log/redact.go
+++ b/middleware/log/redact.go
@@ -3,34 +3,18 @@ package log
 import (
 	"context"
 
-	"github.com/rs/zerolog/log"
 	"github.com/runabol/tork"
-	"github.com/runabol/tork/datastore"
 	"github.com/runabol/tork/internal/redact"
 )
 
-func Redact(ds datastore.Datastore) MiddlewareFunc {
-	redacter := redact.NewRedacter(ds)
+func Redact(redacter *redact.Redacter) MiddlewareFunc {
 	return func(next HandlerFunc) HandlerFunc {
 		return func(ctx context.Context, et EventType, l []*tork.TaskLogPart) error {
 			if et != Read {
 				return next(ctx, et, l)
 			}
-			if len(l) == 0 {
-				return next(ctx, et, l)
-			}
-			task, err := ds.GetTaskByID(ctx, l[0].TaskID)
-			if err != nil {
-				log.Error().Err(err).Msgf("error getting task for log")
+			if err := redacter.RedactTaskLogParts(ctx, l); err != nil {
 				return err
-			}
-			job, err := ds.GetJobByID(ctx, task.JobID)
-			if err != nil {
-				log.Error().Err(err).Msgf("error getting job for log")
-				return err
-			}
-			for _, p := range l {
-				redacter.RedactTaskLogPart(p, job.Secrets)
 			}
 			return next(ctx, et, l)
 		}

--- a/middleware/log/redact_test.go
+++ b/middleware/log/redact_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/runabol/tork"
 	"github.com/runabol/tork/datastore/postgres"
+	"github.com/runabol/tork/internal/redact"
 	"github.com/runabol/tork/internal/uuid"
 	"github.com/stretchr/testify/assert"
 )
@@ -36,7 +37,7 @@ func TestRedactOnRead(t *testing.T) {
 	err = ds.CreateTask(context.Background(), tk)
 	assert.NoError(t, err)
 
-	hm := ApplyMiddleware(NoOpHandlerFunc, []MiddlewareFunc{Redact(ds)})
+	hm := ApplyMiddleware(NoOpHandlerFunc, []MiddlewareFunc{Redact(redact.NewRedacter(ds))})
 	p := &tork.TaskLogPart{
 		Contents: "line 1 -- 1234",
 		TaskID:   tk.ID,


### PR DESCRIPTION
Adds configurable exclusion patterns for redaction, so broadly-matched keys and secrets can be carved out without disabling redaction entirely.

* Introduces `middleware.job.redact.exclude.patterns` (wildcard-supported)
* Exclusions apply to key-name matching and secret-name value matching; excluded keys skip include-pattern redaction, and excluded secret names are not scanned when redacting values or logs
* Log og redaction uses the same patterns and exclusions

Example config:

```toml
[middleware.job.redact]
patterns = ["*SECRET*"]
exclude.patterns = ["*_public"]
```