### PR TITLE
Feature: add task result limit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ config.local.toml
 # Binaries
 tmp/
 config.toml
+tork

--- a/configs/sample.config.toml
+++ b/configs/sample.config.toml
@@ -109,6 +109,7 @@ default = 1 # numbers of concurrent subscribers
 cpus = ""    # supports fractions
 memory = ""  # e.g. 100m 
 timeout = "" # e.g. 3h
+result = 65536 # max task result size in bytes (default: 64 KiB)
 
 
 [mounts.bind]

--- a/engine/worker.go
+++ b/engine/worker.go
@@ -33,6 +33,7 @@ func (e *Engine) initWorker() error {
 			DefaultCPUsLimit:   conf.String("worker.limits.cpus"),
 			DefaultMemoryLimit: conf.String("worker.limits.memory"),
 			DefaultTimeout:     conf.String("worker.limits.timeout"),
+			MaxResultSize:      conf.IntDefault("worker.limits.result", worker.DefaultMaxTaskResultSize),
 		},
 		Address:    conf.String("worker.address"),
 		Middleware: e.cfg.Middleware.Task,

--- a/internal/worker/limits.go
+++ b/internal/worker/limits.go
@@ -1,0 +1,4 @@
+package worker
+
+// DefaultMaxTaskResultSize is the default maximum task result size in bytes.
+const DefaultMaxTaskResultSize = 64 << 10 // 64 KiB

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -50,6 +50,7 @@ type Limits struct {
 	DefaultCPUsLimit   string
 	DefaultMemoryLimit string
 	DefaultTimeout     string
+	MaxResultSize      int
 }
 
 type runningTask struct {
@@ -66,6 +67,9 @@ func NewWorker(cfg Config) (*Worker, error) {
 	}
 	if cfg.Runtime == nil {
 		return nil, errors.New("must provide runtime")
+	}
+	if cfg.Limits.MaxResultSize <= 0 {
+		cfg.Limits.MaxResultSize = DefaultMaxTaskResultSize
 	}
 	tasks := new(syncx.Map[string, runningTask])
 	w := &Worker{
@@ -197,6 +201,13 @@ func (w *Worker) doRunTask(ctx context.Context, t *tork.Task) error {
 		t.FailedAt = &finished
 		t.State = tork.TaskStateFailed
 		t.Error = err.Error()
+		return nil
+	}
+	if len(t.Result) > w.limits.MaxResultSize {
+		finished := time.Now().UTC()
+		t.FailedAt = &finished
+		t.State = tork.TaskStateFailed
+		t.Error = fmt.Errorf("task result exceeds maximum size of %d bytes (got %d)", w.limits.MaxResultSize, len(t.Result)).Error()
 		return nil
 	}
 	finished := time.Now().UTC()

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -544,3 +544,50 @@ func Test_handleTaskRunDefaultLimitOK(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "/somevolume", t1.Mounts[0].Target)
 }
+
+type stubRuntime struct {
+	result string
+	err    error
+}
+
+func (s *stubRuntime) Run(ctx context.Context, t *tork.Task) error {
+	if s.err != nil {
+		return s.err
+	}
+	t.Result = s.result
+	return nil
+}
+
+func (s *stubRuntime) HealthCheck(ctx context.Context) error {
+	return nil
+}
+
+func Test_handleTaskRunResultTooLarge(t *testing.T) {
+	b := broker.NewInMemoryBroker()
+
+	errorsCh := make(chan any)
+	err := b.SubscribeForTasks(broker.QUEUE_ERROR, func(tk *tork.Task) error {
+		assert.Equal(t, tork.TaskStateFailed, tk.State)
+		assert.Contains(t, tk.Error, "task result exceeds maximum size of 5 bytes (got 6)")
+		close(errorsCh)
+		return nil
+	})
+	assert.NoError(t, err)
+
+	w, err := NewWorker(Config{
+		Broker:  b,
+		Runtime: &stubRuntime{result: "123456"},
+		Limits: Limits{
+			MaxResultSize: 5,
+		},
+	})
+	assert.NoError(t, err)
+
+	err = w.handleTask(&tork.Task{
+		ID:    uuid.NewUUID(),
+		State: tork.TaskStateRunning,
+	})
+
+	assert.NoError(t, err)
+	<-errorsCh
+}


### PR DESCRIPTION
Adds a configurable maximum size for task results, enforced on the worker after runtime execution.

* New `worker.limits.result` setting (bytes, default 64 KiB)
* Oversized results fail the task with a clear error: `task result exceeds maximum size of N bytes (got M)`