### PR TITLE
Add paginated job execution endpoint and lightweight job summary API

### DIFF
--- a/README.md
+++ b/README.md
@@ -865,7 +865,22 @@ Query params: `page`, `size` (1–20), `q` (full-text search).
 
 ```shell
 GET /jobs/<JOB_ID>
+GET /jobs/<JOB_ID>?full=false
 ```
+
+By default, returns the full job (definition, execution tasks, context, etc.). Pass `full=false` to return a lightweight `JobSummary` — useful for status polling on large jobs.
+
+### Get job execution
+
+```shell
+GET /jobs/<JOB_ID>/execution?page=1&size=25&sort=desc
+```
+
+Returns a paginated list of execution tasks as `TaskSummary` objects. Query params:
+
+- `page` – page number (default: `1`)
+- `size` – page size (default: `25`, max: `100`)
+- `sort` – `desc` (default, most recently started first) or `asc` (matches full job execution order)
 
 ### Submit a job
 

--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -40,6 +40,8 @@ type Datastore interface {
 	CreateJob(ctx context.Context, j *tork.Job) error
 	UpdateJob(ctx context.Context, id string, modify func(u *tork.Job) error) error
 	GetJobByID(ctx context.Context, id string) (*tork.Job, error)
+	GetJobSummaryByID(ctx context.Context, id string) (*tork.Job, error)
+	GetJobExecution(ctx context.Context, jobID string, page, size int, sort string) (*Page[*tork.TaskSummary], error)
 	GetJobLogParts(ctx context.Context, jobID, q string, page, size int) (*Page[*tork.TaskLogPart], error)
 	GetJobs(ctx context.Context, currentUser, q string, page, size int) (*Page[*tork.JobSummary], error)
 

--- a/datastore/postgres/postgres.go
+++ b/datastore/postgres/postgres.go
@@ -841,6 +841,67 @@ func (ds *PostgresDatastore) GetJobByID(ctx context.Context, id string) (*tork.J
 	return r.toJob(tasks, exec, u, perms, ds.encryptionKey)
 }
 
+func (ds *PostgresDatastore) GetJobSummaryByID(ctx context.Context, id string) (*tork.Job, error) {
+	r := jobRecord{}
+	if err := ds.get(&r, `SELECT * FROM jobs where id = $1`, id); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, datastore.ErrJobNotFound
+		}
+		return nil, errors.Wrapf(err, "error fetching job from db")
+	}
+	u, err := ds.GetUser(ctx, r.CreatedBy)
+	if err != nil {
+		return nil, err
+	}
+	return r.toJob([]*tork.Task{}, []*tork.Task{}, u, []*tork.Permission{}, ds.encryptionKey)
+}
+
+func jobExecutionOrder(sort string) string {
+	if sort == "asc" {
+		return "position asc, started_at asc nulls last, created_at asc"
+	}
+	return "started_at desc nulls last, position desc, created_at desc"
+}
+
+func (ds *PostgresDatastore) GetJobExecution(ctx context.Context, jobID string, page, size int, sort string) (*datastore.Page[*tork.TaskSummary], error) {
+	var exists bool
+	if err := ds.get(&exists, `SELECT EXISTS(SELECT 1 FROM jobs WHERE id = $1)`, jobID); err != nil {
+		return nil, errors.Wrapf(err, "error checking if job exists")
+	}
+	if !exists {
+		return nil, datastore.ErrJobNotFound
+	}
+	offset := (page - 1) * size
+	rs := make([]taskRecord, 0)
+	q := fmt.Sprintf(`SELECT * 
+	      FROM tasks 
+		  WHERE job_id = $1 
+		  ORDER BY %s
+		  OFFSET %d LIMIT %d`, jobExecutionOrder(sort), offset, size)
+	if err := ds.select_(&rs, q, jobID); err != nil {
+		return nil, errors.Wrapf(err, "error getting job execution from db")
+	}
+	items := make([]*tork.TaskSummary, len(rs))
+	for i, r := range rs {
+		items[i] = r.toTaskSummary()
+	}
+	var count *int
+	if err := ds.get(&count, `SELECT count(*) FROM tasks WHERE job_id = $1`, jobID); err != nil {
+		return nil, errors.Wrapf(err, "error getting job execution count")
+	}
+	totalPages := *count / size
+	if *count%size != 0 {
+		totalPages = totalPages + 1
+	}
+	return &datastore.Page[*tork.TaskSummary]{
+		Items:      items,
+		Number:     page,
+		Size:       len(items),
+		TotalPages: totalPages,
+		TotalItems: *count,
+	}, nil
+}
+
 func (ds *PostgresDatastore) GetActiveTasks(ctx context.Context, jobID string) ([]*tork.Task, error) {
 	rs := make([]taskRecord, 0)
 	q := `SELECT * 

--- a/datastore/postgres/postgres_test.go
+++ b/datastore/postgres/postgres_test.go
@@ -614,6 +614,89 @@ func TestPostgresUpdateJobConcurrently(t *testing.T) {
 	assert.Equal(t, 5, j2.Position)
 }
 
+func TestPostgresGetJobSummaryByID(t *testing.T) {
+	ctx := context.Background()
+	ds, err := NewTestDatastore()
+	assert.NoError(t, err)
+	defer fns.CloseIgnore(ds)
+	now := time.Now().UTC()
+	j1 := tork.Job{
+		ID:        uuid.NewUUID(),
+		State:     tork.JobStateRunning,
+		Name:      "summary-job",
+		TaskCount: 3,
+		Tasks: []*tork.Task{{
+			Name: "task-def",
+		}},
+	}
+	err = ds.CreateJob(ctx, &j1)
+	assert.NoError(t, err)
+	err = ds.CreateTask(ctx, &tork.Task{
+		ID:        uuid.NewUUID(),
+		JobID:     j1.ID,
+		Position:  1,
+		Name:      "exec-task",
+		State:     tork.TaskStateCompleted,
+		CreatedAt: &now,
+	})
+	assert.NoError(t, err)
+
+	js, err := ds.GetJobSummaryByID(ctx, j1.ID)
+	assert.NoError(t, err)
+	assert.Equal(t, j1.ID, js.ID)
+	assert.Equal(t, "summary-job", js.Name)
+	assert.Equal(t, 3, js.TaskCount)
+	assert.Empty(t, js.Tasks)
+	assert.Empty(t, js.Execution)
+
+	_, err = ds.GetJobSummaryByID(ctx, "not-a-job")
+	assert.ErrorIs(t, err, datastore.ErrJobNotFound)
+}
+
+func TestPostgresGetJobExecution(t *testing.T) {
+	ctx := context.Background()
+	ds, err := NewTestDatastore()
+	assert.NoError(t, err)
+	defer fns.CloseIgnore(ds)
+	j1 := tork.Job{
+		ID:    uuid.NewUUID(),
+		State: tork.JobStateRunning,
+	}
+	err = ds.CreateJob(ctx, &j1)
+	assert.NoError(t, err)
+	now := time.Now().UTC()
+	for i := 0; i < 5; i++ {
+		started := now.Add(time.Duration(i) * time.Minute)
+		err = ds.CreateTask(ctx, &tork.Task{
+			ID:        uuid.NewUUID(),
+			JobID:     j1.ID,
+			Position:  i + 1,
+			Name:      fmt.Sprintf("task-%d", i+1),
+			State:     tork.TaskStateCompleted,
+			CreatedAt: &now,
+			StartedAt: &started,
+		})
+		assert.NoError(t, err)
+	}
+
+	page, err := ds.GetJobExecution(ctx, j1.ID, 1, 2, "desc")
+	assert.NoError(t, err)
+	assert.Equal(t, 1, page.Number)
+	assert.Equal(t, 2, len(page.Items))
+	assert.Equal(t, 5, page.TotalItems)
+	assert.Equal(t, 3, page.TotalPages)
+	assert.Equal(t, "task-5", page.Items[0].Name)
+	assert.Equal(t, "task-4", page.Items[1].Name)
+
+	page, err = ds.GetJobExecution(ctx, j1.ID, 1, 2, "asc")
+	assert.NoError(t, err)
+	assert.Equal(t, "task-1", page.Items[0].Name)
+	assert.Equal(t, "task-2", page.Items[1].Name)
+
+	_, err = ds.GetJobExecution(ctx, "not-a-job", 1, 10, "desc")
+	assert.ErrorIs(t, err, datastore.ErrJobNotFound)
+}
+
 func TestPostgresGetJobs(t *testing.T) {
 	ctx := context.Background()
 	schemaName := fmt.Sprintf("tork%d", rand.Int())

--- a/datastore/postgres/record.go
+++ b/datastore/postgres/record.go
@@ -281,6 +281,26 @@ func (r taskRecord) toTask() (*tork.Task, error) {
 	}, nil
 }
 
+func (r taskRecord) toTaskSummary() *tork.TaskSummary {
+	return &tork.TaskSummary{
+		ID:          r.ID,
+		JobID:       r.JobID,
+		Position:    r.Position,
+		Progress:    r.Progress,
+		Name:        r.Name,
+		Description: r.Description,
+		State:       tork.TaskState(r.State),
+		CreatedAt:   &r.CreatedAt,
+		ScheduledAt: r.ScheduledAt,
+		StartedAt:   r.StartedAt,
+		CompletedAt: r.CompletedAt,
+		Error:       r.Error,
+		Result:      r.Result,
+		Var:         r.Var,
+		Tags:        r.Tags,
+	}
+}
+
 func (r nodeRecord) toNode() *tork.Node {
 	n := tork.Node{
 		ID:              r.ID,

--- a/engine/datastore.go
+++ b/engine/datastore.go
@@ -113,6 +113,20 @@ func (ds *datastoreProxy) GetJobByID(ctx context.Context, id string) (*tork.Job,
 	return ds.ds.GetJobByID(ctx, id)
 }
 
+func (ds *datastoreProxy) GetJobSummaryByID(ctx context.Context, id string) (*tork.Job, error) {
+	if err := ds.checkInit(); err != nil {
+		return nil, err
+	}
+	return ds.ds.GetJobSummaryByID(ctx, id)
+}
+
+func (ds *datastoreProxy) GetJobExecution(ctx context.Context, jobID string, page, size int, sort string) (*datastore.Page[*tork.TaskSummary], error) {
+	if err := ds.checkInit(); err != nil {
+		return nil, err
+	}
+	return ds.ds.GetJobExecution(ctx, jobID, page, size, sort)
+}
+
 func (ds *datastoreProxy) GetJobLogParts(ctx context.Context, jobID, q string, page, size int) (*datastore.Page[*tork.TaskLogPart], error) {
 	if err := ds.checkInit(); err != nil {
 		return nil, err

--- a/internal/coordinator/api/api.go
+++ b/internal/coordinator/api/api.go
@@ -34,9 +34,10 @@ import (
 )
 
 const (
-	MIN_PORT          = 8000
-	MAX_PORT          = 8100
-	MAX_LOG_PAGE_SIZE = 100
+	MIN_PORT                = 8000
+	MAX_PORT                = 8100
+	MAX_LOG_PAGE_SIZE       = 100
+	MAX_EXECUTION_PAGE_SIZE = 100
 )
 
 type HealthResponse struct {
@@ -137,6 +138,7 @@ func NewAPI(cfg Config) (*API, error) {
 	if v, ok := cfg.Enabled["jobs"]; !ok || v {
 		r.POST("/jobs", s.createJob)
 		r.GET("/jobs/:id", s.getJob)
+		r.GET("/jobs/:id/execution", s.getJobExecution)
 		r.GET("/jobs/:id/log", s.getJobLog)
 		r.GET("/jobs", s.listJobs)
 		r.PUT("/jobs/:id/cancel", s.cancelJob)
@@ -420,9 +422,28 @@ func bindInputYAML(target any, r io.ReadCloser) error {
 // @Failure 404 {object} echo.HTTPError
 // @Router /jobs/{id} [get]
 // @Param id path string true "Job ID"
+// @Param full query bool false "return full job (default: true)"
 func (s *API) getJob(c echo.Context) error {
 	ctx := c.Request().Context()
 	id := c.Param("id")
+	full := true
+	if fullParam := c.QueryParam("full"); fullParam != "" {
+		parsed, err := strconv.ParseBool(fullParam)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("invalid full: %s", fullParam))
+		}
+		full = parsed
+	}
+	if !full {
+		j, err := s.ds.GetJobSummaryByID(ctx, id)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusNotFound, err)
+		}
+		if err := s.onReadJob(ctx, job.Read, j); err != nil {
+			return err
+		}
+		return c.JSON(http.StatusOK, tork.NewJobSummary(j))
+	}
 	j, err := s.ds.GetJobByID(ctx, id)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusNotFound, err)
@@ -431,6 +452,57 @@ func (s *API) getJob(c echo.Context) error {
 		return err
 	}
 	return c.JSON(http.StatusOK, j)
+}
+
+// getJobExecution
+// @Summary Get a job's execution tasks
+// @Tags jobs
+// @Produce application/json
+// @Success 200 {object} datastore.Page[tork.TaskSummary]
+// @Failure 404 {object} echo.HTTPError
+// @Router /jobs/{id}/execution [get]
+// @Param id path string true "Job ID"
+// @Param page query int false "page number"
+// @Param size query int false "page size"
+// @Param sort query string false "sort order (desc or asc, default: desc)"
+func (s *API) getJobExecution(c echo.Context) error {
+	id := c.Param("id")
+	sort := c.QueryParam("sort")
+	if sort == "" {
+		sort = "desc"
+	}
+	if sort != "desc" && sort != "asc" {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("invalid sort: %s", sort))
+	}
+	ps := c.QueryParam("page")
+	if ps == "" {
+		ps = "1"
+	}
+	page, err := strconv.Atoi(ps)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("invalid page number: %s", ps))
+	}
+	if page < 1 {
+		page = 1
+	}
+	si := c.QueryParam("size")
+	if si == "" {
+		si = "25"
+	}
+	size, err := strconv.Atoi(si)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("invalid size: %s", si))
+	}
+	if size < 1 {
+		size = 1
+	} else if size > MAX_EXECUTION_PAGE_SIZE {
+		size = MAX_EXECUTION_PAGE_SIZE
+	}
+	exec, err := s.ds.GetJobExecution(c.Request().Context(), id, page, size, sort)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusNotFound, err.Error())
+	}
+	return c.JSON(http.StatusOK, exec)
 }
 
 // getJobLog

--- a/internal/coordinator/api/api_test.go
+++ b/internal/coordinator/api/api_test.go
@@ -396,6 +396,117 @@ func Test_getJob(t *testing.T) {
 	assert.NoError(t, ds.Close())
 }
 
+func Test_getJob_full_false(t *testing.T) {
+	ds, err := postgres.NewTestDatastore()
+	assert.NoError(t, err)
+	err = ds.CreateJob(context.Background(), &tork.Job{
+		ID:    "1234",
+		State: tork.JobStatePending,
+		Name:  "test-job",
+	})
+	assert.NoError(t, err)
+	api, err := NewAPI(Config{
+		DataStore: ds,
+		Broker:    broker.NewInMemoryBroker(),
+	})
+	assert.NoError(t, err)
+	req, err := http.NewRequest("GET", "/jobs/1234?full=false", nil)
+	assert.NoError(t, err)
+	w := httptest.NewRecorder()
+	api.server.Handler.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	body, err := io.ReadAll(w.Body)
+	assert.NoError(t, err)
+	js := tork.JobSummary{}
+	err = json.Unmarshal(body, &js)
+	assert.NoError(t, err)
+	assert.Equal(t, "1234", js.ID)
+	assert.Equal(t, "test-job", js.Name)
+	assert.Equal(t, tork.JobStatePending, js.State)
+	assert.NoError(t, ds.Close())
+}
+
+func Test_getJob_invalid_full(t *testing.T) {
+	ds, err := postgres.NewTestDatastore()
+	assert.NoError(t, err)
+	err = ds.CreateJob(context.Background(), &tork.Job{
+		ID:    "1234",
+		State: tork.JobStatePending,
+	})
+	assert.NoError(t, err)
+	api, err := NewAPI(Config{
+		DataStore: ds,
+		Broker:    broker.NewInMemoryBroker(),
+	})
+	assert.NoError(t, err)
+	req, err := http.NewRequest("GET", "/jobs/1234?full=maybe", nil)
+	assert.NoError(t, err)
+	w := httptest.NewRecorder()
+	api.server.Handler.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.NoError(t, ds.Close())
+}
+
+func Test_getJobExecution(t *testing.T) {
+	ctx := context.Background()
+	ds, err := postgres.NewTestDatastore()
+	assert.NoError(t, err)
+	j1 := tork.Job{
+		ID:    uuid.NewUUID(),
+		State: tork.JobStateRunning,
+	}
+	err = ds.CreateJob(ctx, &j1)
+	assert.NoError(t, err)
+	now := time.Now().UTC()
+	for i := 0; i < 5; i++ {
+		started := now.Add(time.Duration(i) * time.Minute)
+		err = ds.CreateTask(ctx, &tork.Task{
+			ID:        uuid.NewUUID(),
+			JobID:     j1.ID,
+			Position:  i + 1,
+			Name:      fmt.Sprintf("task-%d", i+1),
+			State:     tork.TaskStateCompleted,
+			CreatedAt: &now,
+			StartedAt: &started,
+		})
+		assert.NoError(t, err)
+	}
+	api, err := NewAPI(Config{
+		DataStore: ds,
+		Broker:    broker.NewInMemoryBroker(),
+	})
+	assert.NoError(t, err)
+	req, err := http.NewRequest("GET", fmt.Sprintf("/jobs/%s/execution?page=1&size=2", j1.ID), nil)
+	assert.NoError(t, err)
+	w := httptest.NewRecorder()
+	api.server.Handler.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	body, err := io.ReadAll(w.Body)
+	assert.NoError(t, err)
+	page := datastore.Page[*tork.TaskSummary]{}
+	err = json.Unmarshal(body, &page)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, page.Number)
+	assert.Equal(t, 2, len(page.Items))
+	assert.Equal(t, 5, page.TotalItems)
+	assert.Equal(t, 3, page.TotalPages)
+	assert.Equal(t, "task-5", page.Items[0].Name)
+	assert.Equal(t, "task-4", page.Items[1].Name)
+
+	req, err = http.NewRequest("GET", fmt.Sprintf("/jobs/%s/execution?page=1&size=2&sort=asc", j1.ID), nil)
+	assert.NoError(t, err)
+	w = httptest.NewRecorder()
+	api.server.Handler.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	body, err = io.ReadAll(w.Body)
+	assert.NoError(t, err)
+	err = json.Unmarshal(body, &page)
+	assert.NoError(t, err)
+	assert.Equal(t, "task-1", page.Items[0].Name)
+	assert.Equal(t, "task-2", page.Items[1].Name)
+	assert.NoError(t, ds.Close())
+}
+
 func Test_cancelRunningJob(t *testing.T) {
 	ctx := context.Background()
 	ds, err := postgres.NewTestDatastore()

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -197,9 +197,9 @@ func TestRedactJob(t *testing.T) {
 func TestRedactJobSecrets(t *testing.T) {
 	o := &tork.Job{
 		Secrets: map[string]string{
-			"db_password":   "secret123",
-			"token_public":  "public-token",
-			"config_path":   "/etc/app",
+			"db_password":  "secret123",
+			"token_public": "public-token",
+			"config_path":  "/etc/app",
 		},
 	}
 	j := o.Clone()


### PR DESCRIPTION
## Summary

Large jobs (especially those with `parallel`/`each` fan-out) produce heavy API responses because `GET /jobs/:id` always loads and returns the full job graph — every execution task with full config, plus job definition and context.

This PR adds backwards-compatible endpoints and query options so clients can fetch job metadata and execution tasks incrementally, without changing the default behavior of existing integrations.

- Add `GET /jobs/:id/execution` — paginated execution tasks as `TaskSummary` (`page`/`size`, default size 25, max 100)
- Add `?full=false` on `GET /jobs/:id` — returns a `JobSummary` without loading execution tasks from the database (default `full=true` preserves existing behavior)
- Add `GetJobSummaryByID` and `GetJobExecution` datastore methods with efficient Postgres queries (`LIMIT`/`OFFSET` on `tasks`, no full job-definition unmarshaling for summaries)

## API changes

| Endpoint | Change |
|---|---|
| `GET /jobs/:id` | Unchanged by default (`full=true`). Pass `?full=false` for `JobSummary`. |
| `GET /jobs/:id/execution` | **New.** Paginated `datastore.Page[TaskSummary]`. |

### Examples

```bash
# Existing behavior (unchanged)
GET /jobs/{id}

# Lightweight status polling
GET /jobs/{id}?full=false

# Paginated execution for large jobs
GET /jobs/{id}/execution?page=1&size=50