### PR TITLE
Fix: complete each task over an empty list instead of hanging

### DIFF
--- a/internal/coordinator/scheduler/scheduler.go
+++ b/internal/coordinator/scheduler/scheduler.go
@@ -220,6 +220,13 @@ func (s *Scheduler) scheduleEachTask(ctx context.Context, t *tork.Task) error {
 	}); err != nil {
 		return errors.Wrapf(err, "error updating task in datastore")
 	}
+	// An empty list has no child tasks to complete the each, so it would hang
+	// RUNNING forever. Complete it now so the job can advance.
+	if len(list) == 0 {
+		t.State = tork.TaskStateCompleted
+		t.CompletedAt = &now
+		return s.broker.PublishTask(ctx, broker.QUEUE_COMPLETED, t)
+	}
 	for ix, item := range list {
 		cx := j.Context.Clone().AsMap()
 		eachVar := t.Each.Var

--- a/internal/coordinator/scheduler/scheduler_test.go
+++ b/internal/coordinator/scheduler/scheduler_test.go
@@ -289,6 +289,64 @@ func Test_scheduleEachTask(t *testing.T) {
 	assert.NoError(t, ds.Close())
 }
 
+func Test_scheduleEachTaskEmptyList(t *testing.T) {
+	ctx := context.Background()
+	b := broker.NewInMemoryBroker()
+
+	// No child tasks should ever be published for an empty list.
+	var pendingCount atomic.Int32
+	err := b.SubscribeForTasks(broker.QUEUE_PENDING, func(tk *tork.Task) error {
+		pendingCount.Add(1)
+		return nil
+	})
+	assert.NoError(t, err)
+
+	// The each parent should instead be published to the completed queue so the
+	// job can advance rather than hang RUNNING forever.
+	completed := make(chan *tork.Task, 1)
+	err = b.SubscribeForTasks(broker.QUEUE_COMPLETED, func(tk *tork.Task) error {
+		completed <- tk
+		return nil
+	})
+	assert.NoError(t, err)
+
+	ds, err := postgres.NewTestDatastore()
+	assert.NoError(t, err)
+	s := NewScheduler(ds, b)
+	assert.NotNil(t, s)
+
+	j := &tork.Job{ID: uuid.NewUUID(), Name: "test job"}
+	assert.NoError(t, ds.CreateJob(ctx, j))
+
+	now := time.Now().UTC()
+	tk := &tork.Task{
+		ID:        uuid.NewUUID(),
+		JobID:     j.ID,
+		CreatedAt: &now,
+		Each: &tork.EachTask{
+			List: "{{ sequence (2,2) }}", // empty list
+			Task: &tork.Task{Queue: "test-queue"},
+		},
+	}
+	assert.NoError(t, ds.CreateTask(ctx, tk))
+
+	err = s.scheduleEachTask(ctx, tk)
+	assert.NoError(t, err)
+
+	// the parent each task should be completed
+	select {
+	case ct := <-completed:
+		assert.Equal(t, tk.ID, ct.ID)
+		assert.Equal(t, tork.TaskStateCompleted, ct.State)
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected the empty each task to be published as completed")
+	}
+
+	// and no child tasks should have been scheduled
+	assert.Equal(t, int32(0), pendingCount.Load())
+	assert.NoError(t, ds.Close())
+}
+
 func Test_scheduleEachTaskNotaList(t *testing.T) {
 	ctx := context.Background()
 	b := broker.NewInMemoryBroker()


### PR DESCRIPTION
## Summary

- Fixes a bug where `each` tasks whose list expression evaluates to an empty list hang in `RUNNING` forever and block job completion.
- When `scheduleEachTask` runs over an empty list, it now immediately publishes the parent task to the completed queue instead of waiting for child tasks that will never be created.
- Adds `Test_scheduleEachTaskEmptyList` to verify the parent is completed and no child tasks are scheduled.

## Problem

An `each` task is marked `RUNNING` and its `Each.Size` is set from the evaluated list. When that list is empty, no child tasks are created. Parent completion normally happens in `completeEachTask` when all children finish — but with zero children, that path is never reached, so the parent stays `RUNNING` and the job never advances.

## Solution

After marking the task as running, if `len(list) == 0`, set the task state to `COMPLETED` and publish it to `QUEUE_COMPLETED` so the job can proceed.