### PR TITLE
Fix max timeout

### DIFF
--- a/configs/sample.config.toml
+++ b/configs/sample.config.toml
@@ -104,11 +104,11 @@ name = "Worker"
 [worker.queues]
 default = 1 # numbers of concurrent subscribers
 
-# default task limits
+# task limits
 [worker.limits]
 cpus = ""    # supports fractions
 memory = ""  # e.g. 100m 
-timeout = "" # e.g. 3h
+timeout = "" # max task timeout, e.g. 3h
 result = 65536 # max task result size in bytes (default: 64 KiB)
 
 

--- a/engine/worker.go
+++ b/engine/worker.go
@@ -32,7 +32,7 @@ func (e *Engine) initWorker() error {
 		Limits: worker.Limits{
 			DefaultCPUsLimit:   conf.String("worker.limits.cpus"),
 			DefaultMemoryLimit: conf.String("worker.limits.memory"),
-			DefaultTimeout:     conf.String("worker.limits.timeout"),
+			Timeout:            conf.String("worker.limits.timeout"),
 			MaxResultSize:      conf.IntDefault("worker.limits.result", worker.DefaultMaxTaskResultSize),
 		},
 		Address:    conf.String("worker.address"),

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -49,7 +49,7 @@ type Config struct {
 type Limits struct {
 	DefaultCPUsLimit   string
 	DefaultMemoryLimit string
-	DefaultTimeout     string
+	Timeout            string
 	MaxResultSize      int
 }
 
@@ -119,8 +119,22 @@ func (w *Worker) doHandleTask(ctx context.Context, t *tork.Task) error {
 	if t.Limits != nil && t.Limits.Memory == "" {
 		t.Limits.Memory = w.limits.DefaultMemoryLimit
 	}
-	if t.Timeout == "" {
-		t.Timeout = w.limits.DefaultTimeout
+	if w.limits.Timeout != "" {
+		limitDur, err := time.ParseDuration(w.limits.Timeout)
+		if err != nil {
+			return errors.Wrapf(err, "invalid worker timeout duration: %s", w.limits.Timeout)
+		}
+		if t.Timeout == "" {
+			t.Timeout = w.limits.Timeout
+		} else {
+			taskDur, err := time.ParseDuration(t.Timeout)
+			if err != nil {
+				return errors.Wrapf(err, "invalid timeout duration: %s", t.Timeout)
+			}
+			if taskDur > limitDur {
+				t.Timeout = w.limits.Timeout
+			}
+		}
 	}
 	adapter := func(ctx context.Context, et task.EventType, t *tork.Task) error {
 		return w.runTask(t)

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -432,7 +432,7 @@ func Test_sendHeartbeat(t *testing.T) {
 	assert.NoError(t, w.Stop())
 }
 
-func Test_handleTaskRunDefaultLimitExceeded(t *testing.T) {
+func Test_handleTaskRunTimeoutExceeded(t *testing.T) {
 	rt, err := docker.NewDockerRuntime()
 	assert.NoError(t, err)
 
@@ -442,7 +442,7 @@ func Test_handleTaskRunDefaultLimitExceeded(t *testing.T) {
 		Broker:  b,
 		Runtime: rt,
 		Limits: Limits{
-			DefaultTimeout: "1s",
+			Timeout: "1s",
 		},
 	})
 	assert.NoError(t, err)
@@ -489,7 +489,7 @@ func Test_handleTaskRunDefaultLimitExceeded(t *testing.T) {
 	assert.Equal(t, "/somevolume", t1.Mounts[0].Target)
 }
 
-func Test_handleTaskRunDefaultLimitOK(t *testing.T) {
+func Test_handleTaskRunTimeoutOK(t *testing.T) {
 	rt, err := docker.NewDockerRuntime()
 	assert.NoError(t, err)
 
@@ -499,7 +499,7 @@ func Test_handleTaskRunDefaultLimitOK(t *testing.T) {
 		Broker:  b,
 		Runtime: rt,
 		Limits: Limits{
-			DefaultTimeout: "5s",
+			Timeout: "5s",
 		},
 	})
 	assert.NoError(t, err)
@@ -524,10 +524,11 @@ func Test_handleTaskRunDefaultLimitOK(t *testing.T) {
 	assert.NoError(t, err)
 
 	t1 := &tork.Task{
-		ID:    uuid.NewUUID(),
-		State: tork.TaskStateRunning,
-		Image: "ubuntu:mantic",
-		CMD:   []string{"sleep", "1"},
+		ID:      uuid.NewUUID(),
+		State:   tork.TaskStateRunning,
+		Image:   "ubuntu:mantic",
+		CMD:     []string{"sleep", "1"},
+		Timeout: "10s",
 		Mounts: []*tork.Mount{
 			{
 				Type:   tork.MountTypeVolume,


### PR DESCRIPTION
## Summary

Fixes `worker.limits.timeout` to enforce a maximum task timeout, which was the original intent of the config.

The worker was incorrectly treating this setting as a **default** timeout — applied only when a task had no timeout set. It now correctly acts as a **maximum**:

- Tasks **without** a timeout are capped at the worker limit
- Tasks **with** a timeout longer than the limit are reduced to the limit
- Tasks **with** a timeout at or below the limit are unchanged

## Fix

| Scenario | Before (bug) | After (correct) |
|---|---|---|
| Task has no timeout, worker limit is `3h` | Task runs with `3h` timeout | Task runs with `3h` timeout |
| Task timeout is `6h`, worker limit is `3h` | Task runs with `6h` timeout | Task runs with `3h` timeout |
| Task timeout is `1h`, worker limit is `3h` | Task runs with `1h` timeout | Task runs with `1h` timeout |
| Worker limit is unset | No worker-level timeout applied | No worker-level timeout applied |