### PR TITLE
fix(worker): buffer stop channel to prevent shutdown deadlock

### DIFF
--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -82,7 +82,7 @@ func NewWorker(cfg Config) (*Worker, error) {
 		tasks:      tasks,
 		limits:     cfg.Limits,
 		api:        newAPI(cfg, tasks),
-		stop:       make(chan any),
+		stop:       make(chan any, 1),
 		middleware: cfg.Middleware,
 	}
 	return w, nil


### PR DESCRIPTION
The worker's stop channel is unbuffered (make(chan any)), and Stop() sends via w.stop <- 1 to signal sendHeartbeats to exit. If Stop() runs before the goroutine reaches its select statement, the send blocks forever, causing a deadlock on shutdown.

Buffer the channel with capacity 1 so the signal always succeeds regardless of timing.