### PR TITLE
feat: add worker cordon to drain nodes for maintenance

### DIFF
--- a/broker/broker.go
+++ b/broker/broker.go
@@ -21,6 +21,9 @@ const (
 type Broker interface {
 	PublishTask(ctx context.Context, qname string, t *tork.Task) error
 	SubscribeForTasks(qname string, handler func(t *tork.Task) error) error
+	// Unsubscribe cancels all consumers for a queue without waiting for
+	// in-flight handlers, which are left to complete and ack.
+	Unsubscribe(qname string) error
 
 	PublishTaskProgress(ctx context.Context, t *tork.Task) error
 	SubscribeForTaskProgress(handler func(t *tork.Task) error) error

--- a/broker/inmemory.go
+++ b/broker/inmemory.go
@@ -115,6 +115,20 @@ func (q *queue) close() {
 	}
 }
 
+// unsubscribeAll cancels all consumers but keeps the queue, so it can be
+// re-subscribed later (e.g. on uncordon).
+func (q *queue) unsubscribeAll() {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	for _, sub := range q.subs {
+		close(sub.terminate)
+		if IsCoordinatorQueue(q.name) {
+			<-sub.terminated
+		}
+	}
+	q.subs = make([]*qsub, 0)
+}
+
 func (q *queue) subscribe(sub func(m any) error) {
 	terminate := make(chan any)
 	terminated := make(chan any)
@@ -126,6 +140,17 @@ func (q *queue) subscribe(sub func(m any) error) {
 	q.mu.Unlock()
 	go func() {
 		for {
+			// prioritize terminate: a closed terminate and a queued message
+			// are both ready in the select below and Go picks at random, so
+			// without this a cancelled consumer keeps draining the queue.
+			// Checking it first each iteration bounds that to at most one
+			// message after cancellation.
+			select {
+			case <-terminate:
+				close(terminated)
+				return
+			default:
+			}
 			select {
 			case <-terminate:
 				close(terminated)
@@ -175,6 +200,16 @@ func (b *InMemoryBroker) subscribe(qname string, handler func(m any) error) erro
 		b.queues.Set(qname, q)
 	}
 	q.subscribe(handler)
+	return nil
+}
+
+func (b *InMemoryBroker) Unsubscribe(qname string) error {
+	q, ok := b.queues.Get(qname)
+	if !ok {
+		log.Warn().Msgf("no active subscriptions found for queue: %s", qname)
+		return nil
+	}
+	q.unsubscribeAll()
 	return nil
 }
 

--- a/broker/inmemory_test.go
+++ b/broker/inmemory_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -116,6 +117,89 @@ func TestInMemoryDeleteQueue(t *testing.T) {
 	qis, err = b.Queues(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(qis))
+}
+
+func TestInMemoryUnsubscribe(t *testing.T) {
+	ctx := context.Background()
+	b := broker.NewInMemoryBroker()
+	qname := fmt.Sprintf("test-queue-%s", uuid.NewUUID())
+	var count int32
+	err := b.SubscribeForTasks(qname, func(t *tork.Task) error {
+		atomic.AddInt32(&count, 1)
+		return nil
+	})
+	assert.NoError(t, err)
+	qis, err := b.Queues(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, qis[0].Subscribers)
+
+	// unsubscribe -- consumers should be gone
+	err = b.Unsubscribe(qname)
+	assert.NoError(t, err)
+	qis, err = b.Queues(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, qis[0].Subscribers)
+	// let the cancelled consumer goroutine fully exit before re-subscribing so
+	// it can't race the new consumer for the next published task.
+	time.Sleep(time.Millisecond * 100)
+
+	// re-subscribe -- delivery resumes for newly published tasks
+	var count2 int32
+	err = b.SubscribeForTasks(qname, func(t *tork.Task) error {
+		atomic.AddInt32(&count2, 1)
+		return nil
+	})
+	assert.NoError(t, err)
+	qis, err = b.Queues(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, qis[0].Subscribers)
+
+	err = b.PublishTask(ctx, qname, &tork.Task{ID: "t2"})
+	assert.NoError(t, err)
+	time.Sleep(time.Millisecond * 100)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&count2))
+}
+
+func TestInMemoryUnsubscribeUnknownQueue(t *testing.T) {
+	b := broker.NewInMemoryBroker()
+	// unsubscribing from a queue that was never subscribed is a no-op
+	err := b.Unsubscribe(fmt.Sprintf("nope-%s", uuid.NewUUID()))
+	assert.NoError(t, err)
+}
+
+// TestInMemoryUnsubscribeStopsBacklog verifies a cancelled consumer does not
+// keep draining a queued backlog: with the terminate case prioritized it may
+// process at most one more task, not the whole queue.
+func TestInMemoryUnsubscribeStopsBacklog(t *testing.T) {
+	ctx := context.Background()
+	b := broker.NewInMemoryBroker()
+	qname := fmt.Sprintf("test-queue-%s", uuid.NewUUID())
+	release := make(chan struct{})
+	started := make(chan struct{}, 1)
+	var count int32
+	err := b.SubscribeForTasks(qname, func(t *tork.Task) error {
+		select {
+		case started <- struct{}{}:
+		default:
+		}
+		<-release // hold the consumer inside the handler
+		atomic.AddInt32(&count, 1)
+		return nil
+	})
+	assert.NoError(t, err)
+
+	// enqueue a backlog and wait until the consumer is busy on the first task
+	for i := 0; i < 20; i++ {
+		assert.NoError(t, b.PublishTask(ctx, qname, &tork.Task{}))
+	}
+	<-started
+
+	assert.NoError(t, b.Unsubscribe(qname))
+	close(release) // let the in-flight (and any single extra) task finish
+	time.Sleep(time.Millisecond * 100)
+
+	// far fewer than the 20 enqueued should have been processed
+	assert.LessOrEqual(t, atomic.LoadInt32(&count), int32(2))
 }
 
 func TestInMemoryPublishAndSubsribeForHeartbeat(t *testing.T) {

--- a/broker/rabbitmq.go
+++ b/broker/rabbitmq.go
@@ -271,11 +271,12 @@ func (b *RabbitMQBroker) subscribe(ctx context.Context, exchange, key, qname str
 	log.Debug().Msgf("created channel %s for queue: %s", cname, qname)
 	id := uuid.NewUUID()
 	sub := &subscription{
-		ch:     ch,
-		qname:  qname,
-		name:   cname,
-		done:   make(chan struct{}),
-		cancel: make(chan struct{}),
+		ch:    ch,
+		qname: qname,
+		// both buffered so neither cancelling nor the goroutine's terminal
+		// done-send blocks when Unsubscribe fires and doesn't wait (cordon)
+		done:   make(chan struct{}, 1),
+		cancel: make(chan struct{}, 1),
 	}
 	b.mu.Lock()
 	b.subscriptions[id] = sub
@@ -627,6 +628,30 @@ func (b *RabbitMQBroker) Shutdown(ctx context.Context) error {
 	b.mu.Lock()
 	b.connPool = []*amqp.Connection{}
 	b.mu.Unlock()
+	return nil
+}
+
+// Unsubscribe cancels all consumers on a queue. It is non-blocking: it signals
+// cancellation and returns without waiting for in-flight handlers, so a busy
+// consumer stops claiming new work at once and exits once its task acks.
+func (b *RabbitMQBroker) Unsubscribe(qname string) error {
+	// collect under lock, signal outside it -- each goroutine takes the lock
+	// itself to remove its subscription when it terminates.
+	b.mu.RLock()
+	subs := make([]*subscription, 0)
+	for _, sub := range b.subscriptions {
+		if sub.qname == qname {
+			subs = append(subs, sub)
+		}
+	}
+	b.mu.RUnlock()
+	if len(subs) == 0 {
+		log.Warn().Msgf("no active subscriptions found for queue: %s", qname)
+		return nil
+	}
+	for _, sub := range subs {
+		sub.cancel <- struct{}{}
+	}
 	return nil
 }
 

--- a/broker/rabbitmq_test.go
+++ b/broker/rabbitmq_test.go
@@ -130,6 +130,76 @@ func TestRabbitMQPublishConcurrent(t *testing.T) {
 	close(processed)
 }
 
+func TestRabbitMQUnsubscribe(t *testing.T) {
+	ctx := context.Background()
+	b, err := NewRabbitMQBroker("amqp://guest:guest@localhost:5672/")
+	assert.NoError(t, err)
+	qname := fmt.Sprintf("%stest-%s", QUEUE_EXCLUSIVE_PREFIX, uuid.NewUUID())
+	var mu sync.Mutex
+	count := 0
+	err = b.SubscribeForTasks(qname, func(t *tork.Task) error {
+		mu.Lock()
+		count++
+		mu.Unlock()
+		return nil
+	})
+	assert.NoError(t, err)
+
+	// deliver one task and confirm it's processed
+	assert.NoError(t, b.PublishTask(ctx, qname, &tork.Task{ID: "before"}))
+	time.Sleep(time.Millisecond * 300)
+	mu.Lock()
+	assert.Equal(t, 1, count)
+	mu.Unlock()
+
+	// unsubscribe -- consumer is cancelled
+	assert.NoError(t, b.Unsubscribe(qname))
+
+	// a task published after unsubscribe must not be processed
+	assert.NoError(t, b.PublishTask(ctx, qname, &tork.Task{ID: "after"}))
+	time.Sleep(time.Millisecond * 300)
+	mu.Lock()
+	assert.Equal(t, 1, count)
+	mu.Unlock()
+
+	// unsubscribing an unknown queue is a no-op
+	assert.NoError(t, b.Unsubscribe(fmt.Sprintf("%snope-%s", QUEUE_EXCLUSIVE_PREFIX, uuid.NewUUID())))
+}
+
+func TestRabbitMQUnsubscribeNonBlockingWhileBusy(t *testing.T) {
+	ctx := context.Background()
+	b, err := NewRabbitMQBroker("amqp://guest:guest@localhost:5672/")
+	assert.NoError(t, err)
+	qname := fmt.Sprintf("%stest-%s", QUEUE_EXCLUSIVE_PREFIX, uuid.NewUUID())
+
+	release := make(chan struct{})
+	started := make(chan struct{})
+	err = b.SubscribeForTasks(qname, func(t *tork.Task) error {
+		close(started)
+		<-release // simulate a long-running task
+		return nil
+	})
+	assert.NoError(t, err)
+
+	// kick off a task and wait until the handler is actually running
+	assert.NoError(t, b.PublishTask(ctx, qname, &tork.Task{ID: "busy"}))
+	<-started
+
+	// Unsubscribe must return promptly even though the consumer is mid-task
+	// (cordon semantics: don't block on in-flight work).
+	done := make(chan error, 1)
+	go func() { done <- b.Unsubscribe(qname) }()
+	select {
+	case err := <-done:
+		assert.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Unsubscribe blocked while a task was in flight")
+	}
+
+	// let the in-flight task complete
+	close(release)
+}
+
 func TestRabbitMQShutdown(t *testing.T) {
 	ctx := context.Background()
 	b, err := NewRabbitMQBroker("amqp://guest:guest@localhost:5672/")

--- a/configs/sample.config.toml
+++ b/configs/sample.config.toml
@@ -104,6 +104,10 @@ name = "Worker"
 [worker.queues]
 default = 1 # numbers of concurrent subscribers
 
+# cordon control
+[worker.cordon]
+token = "" # bearer token for /cordon and /uncordon. if blank, the endpoints are disabled
+
 # task limits
 [worker.limits]
 cpus = ""    # supports fractions

--- a/datastore/postgres/record.go
+++ b/datastore/postgres/record.go
@@ -317,7 +317,8 @@ func (r nodeRecord) toNode() *tork.Node {
 	}
 	// if we hadn't seen an heartbeat for two or more
 	// consecutive periods we consider the node as offline
-	if n.LastHeartbeatAt.Before(time.Now().UTC().Add(-tork.HEARTBEAT_RATE*2)) && n.Status == tork.NodeStatusUP {
+	if n.LastHeartbeatAt.Before(time.Now().UTC().Add(-tork.HEARTBEAT_RATE*2)) &&
+		(n.Status == tork.NodeStatusUP || n.Status == tork.NodeStatusCordoned) {
 		n.Status = tork.NodeStatusOffline
 	}
 	return &n

--- a/datastore/postgres/record_test.go
+++ b/datastore/postgres/record_test.go
@@ -1,0 +1,41 @@
+package postgres
+
+import (
+	"testing"
+	"time"
+
+	"github.com/runabol/tork"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestNodeRecordToNodeStatus covers the status-derivation logic in
+// nodeRecord.toNode(), including the CORDONED handling: a cordoned node whose
+// heartbeats have gone stale must still be derived as OFFLINE (rather than
+// staying stuck at CORDONED), while a freshly-heartbeating cordoned node keeps
+// its CORDONED status.
+func TestNodeRecordToNodeStatus(t *testing.T) {
+	fresh := time.Now().UTC()
+	stale := time.Now().UTC().Add(-tork.HEARTBEAT_RATE * 3)
+
+	cases := []struct {
+		name    string
+		status  tork.NodeStatus
+		hb      time.Time
+		expects tork.NodeStatus
+	}{
+		{"fresh up stays up", tork.NodeStatusUP, fresh, tork.NodeStatusUP},
+		{"stale up becomes offline", tork.NodeStatusUP, stale, tork.NodeStatusOffline},
+		{"fresh cordoned stays cordoned", tork.NodeStatusCordoned, fresh, tork.NodeStatusCordoned},
+		{"stale cordoned becomes offline", tork.NodeStatusCordoned, stale, tork.NodeStatusOffline},
+		{"stale down stays down", tork.NodeStatusDown, stale, tork.NodeStatusDown},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := nodeRecord{
+				Status:          string(tc.status),
+				LastHeartbeatAt: tc.hb,
+			}
+			assert.Equal(t, tc.expects, r.toNode().Status)
+		})
+	}
+}

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1032,12 +1032,14 @@
             "enum": [
                 "UP",
                 "DOWN",
-                "OFFLINE"
+                "OFFLINE",
+                "CORDONED"
             ],
             "x-enum-varnames": [
                 "NodeStatusUP",
                 "NodeStatusDown",
-                "NodeStatusOffline"
+                "NodeStatusOffline",
+                "NodeStatusCordoned"
             ]
         },
         "tork.ParallelTask": {

--- a/engine/broker.go
+++ b/engine/broker.go
@@ -27,6 +27,13 @@ func (b *brokerProxy) SubscribeForTasks(qname string, handler func(t *tork.Task)
 	return b.broker.SubscribeForTasks(qname, handler)
 }
 
+func (b *brokerProxy) Unsubscribe(qname string) error {
+	if err := b.checkInit(); err != nil {
+		return err
+	}
+	return b.broker.Unsubscribe(qname)
+}
+
 func (b *brokerProxy) PublishTaskProgress(ctx context.Context, t *tork.Task) error {
 	if err := b.checkInit(); err != nil {
 		return err

--- a/engine/worker.go
+++ b/engine/worker.go
@@ -35,8 +35,9 @@ func (e *Engine) initWorker() error {
 			Timeout:            conf.String("worker.limits.timeout"),
 			MaxResultSize:      conf.IntDefault("worker.limits.result", worker.DefaultMaxTaskResultSize),
 		},
-		Address:    conf.String("worker.address"),
-		Middleware: e.cfg.Middleware.Task,
+		Address:     conf.String("worker.address"),
+		Middleware:  e.cfg.Middleware.Task,
+		CordonToken: conf.String("worker.cordon.token"),
 	})
 	if err != nil {
 		return errors.Wrapf(err, "error creating worker")

--- a/internal/worker/api.go
+++ b/internal/worker/api.go
@@ -23,25 +23,35 @@ const (
 )
 
 type api struct {
-	server  *http.Server
-	broker  broker.Broker
-	runtime runtime.Runtime
-	tasks   *syncx.Map[string, runningTask]
-	port    int
+	server      *http.Server
+	broker      broker.Broker
+	runtime     runtime.Runtime
+	tasks       *syncx.Map[string, runningTask]
+	worker      *Worker
+	cordonToken string
+	port        int
 }
 
-func newAPI(cfg Config, tasks *syncx.Map[string, runningTask]) *api {
+func newAPI(cfg Config, tasks *syncx.Map[string, runningTask], w *Worker) *api {
 	r := echo.New()
 	s := &api{
-		runtime: cfg.Runtime,
-		broker:  cfg.Broker,
-		tasks:   tasks,
+		runtime:     cfg.Runtime,
+		broker:      cfg.Broker,
+		tasks:       tasks,
+		worker:      w,
+		cordonToken: cfg.CordonToken,
 		server: &http.Server{
 			Addr:    cfg.Address,
 			Handler: r,
 		},
 	}
 	r.GET("/health", s.health)
+	r.GET("/status", s.status)
+	// cordon endpoints require a configured token; disabled without one
+	if s.cordonToken != "" {
+		r.POST("/cordon", s.cordon, s.requireCordonToken)
+		r.POST("/uncordon", s.uncordon, s.requireCordonToken)
+	}
 	return s
 }
 

--- a/internal/worker/api_test.go
+++ b/internal/worker/api_test.go
@@ -18,7 +18,7 @@ func Test_health(t *testing.T) {
 	api := newAPI(Config{
 		Broker:  broker.NewInMemoryBroker(),
 		Runtime: rt,
-	}, &syncx.Map[string, runningTask]{})
+	}, &syncx.Map[string, runningTask]{}, &Worker{})
 	assert.NotNil(t, api)
 	req, err := http.NewRequest("GET", "/health", nil)
 	assert.NoError(t, err)

--- a/internal/worker/cordon.go
+++ b/internal/worker/cordon.go
@@ -1,0 +1,62 @@
+package worker
+
+import (
+	"crypto/subtle"
+	"net/http"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+	"github.com/rs/zerolog/log"
+)
+
+// requireCordonToken enforces the bearer token on the cordon endpoints.
+func (s *api) requireCordonToken(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		auth := c.Request().Header.Get(echo.HeaderAuthorization)
+		const prefix = "Bearer "
+		if !strings.HasPrefix(auth, prefix) {
+			return echo.NewHTTPError(http.StatusUnauthorized, "missing bearer token")
+		}
+		provided := strings.TrimPrefix(auth, prefix)
+		if subtle.ConstantTimeCompare([]byte(provided), []byte(s.cordonToken)) != 1 {
+			return echo.NewHTTPError(http.StatusUnauthorized, "invalid cordon token")
+		}
+		return next(c)
+	}
+}
+
+type workerStatus struct {
+	ID        string `json:"id"`
+	Cordoned  bool   `json:"cordoned"`
+	TaskCount int    `json:"taskCount"`
+}
+
+func (s *api) workerStatus() workerStatus {
+	return workerStatus{
+		ID:        s.worker.id,
+		Cordoned:  s.worker.isCordoned(),
+		TaskCount: s.worker.TaskCount(),
+	}
+}
+
+// status reports the worker's cordon state and in-flight task count -- enough
+// to drive a cordon/drain/stop loop from the host.
+func (s *api) status(c echo.Context) error {
+	return c.JSON(http.StatusOK, s.workerStatus())
+}
+
+func (s *api) cordon(c echo.Context) error {
+	if err := s.worker.Cordon(); err != nil {
+		log.Error().Err(err).Msg("error cordoning worker")
+		return echo.NewHTTPError(http.StatusInternalServerError, "error cordoning worker")
+	}
+	return c.JSON(http.StatusOK, s.workerStatus())
+}
+
+func (s *api) uncordon(c echo.Context) error {
+	if err := s.worker.Uncordon(); err != nil {
+		log.Error().Err(err).Msg("error uncordoning worker")
+		return echo.NewHTTPError(http.StatusInternalServerError, "error uncordoning worker")
+	}
+	return c.JSON(http.StatusOK, s.workerStatus())
+}

--- a/internal/worker/cordon_test.go
+++ b/internal/worker/cordon_test.go
@@ -1,0 +1,184 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/runabol/tork"
+	"github.com/runabol/tork/broker"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCordonUncordon(t *testing.T) {
+	b := broker.NewInMemoryBroker()
+	w, err := NewWorker(Config{
+		Broker:  b,
+		Runtime: &stubRuntime{},
+		Queues:  map[string]int{broker.QUEUE_DEFAULT: 3},
+	})
+	assert.NoError(t, err)
+	assert.NoError(t, w.Start())
+
+	ctx := context.Background()
+
+	// after Start the worker has 3 consumers on the default queue
+	qi, err := b.QueueInfo(ctx, broker.QUEUE_DEFAULT)
+	assert.NoError(t, err)
+	assert.Equal(t, 3, qi.Subscribers)
+	assert.False(t, w.isCordoned())
+
+	// cordon -- consumers on the work queue are cancelled
+	assert.NoError(t, w.Cordon())
+	assert.True(t, w.isCordoned())
+	qi, err = b.QueueInfo(ctx, broker.QUEUE_DEFAULT)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, qi.Subscribers)
+
+	// cordon is idempotent
+	assert.NoError(t, w.Cordon())
+	assert.True(t, w.isCordoned())
+
+	// uncordon -- consumers are restored
+	assert.NoError(t, w.Uncordon())
+	assert.False(t, w.isCordoned())
+	qi, err = b.QueueInfo(ctx, broker.QUEUE_DEFAULT)
+	assert.NoError(t, err)
+	assert.Equal(t, 3, qi.Subscribers)
+
+	// uncordon is idempotent
+	assert.NoError(t, w.Uncordon())
+	assert.False(t, w.isCordoned())
+}
+
+func TestCordonKeepsExclusiveQueue(t *testing.T) {
+	b := broker.NewInMemoryBroker()
+	w, err := NewWorker(Config{
+		Broker:  b,
+		Runtime: &stubRuntime{},
+		Queues:  map[string]int{broker.QUEUE_DEFAULT: 1},
+	})
+	assert.NoError(t, err)
+	assert.NoError(t, w.Start())
+
+	exq := broker.QUEUE_EXCLUSIVE_PREFIX + w.id
+	assert.NoError(t, w.Cordon())
+
+	// the node's exclusive (cancellation) queue must remain subscribed so the
+	// coordinator can still cancel tasks on a cordoned worker.
+	qi, err := b.QueueInfo(context.Background(), exq)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, qi.Subscribers)
+}
+
+func TestCordonEndpointsDisabledWithoutToken(t *testing.T) {
+	b := broker.NewInMemoryBroker()
+	w, err := NewWorker(Config{
+		Broker:  b,
+		Runtime: &stubRuntime{},
+		Queues:  map[string]int{broker.QUEUE_DEFAULT: 1},
+	})
+	assert.NoError(t, err)
+	assert.NoError(t, w.Start())
+
+	// no token configured -> cordon endpoint is not registered
+	req := httptest.NewRequest(http.MethodPost, "/cordon", nil)
+	rec := httptest.NewRecorder()
+	w.api.server.Handler.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.False(t, w.isCordoned())
+}
+
+func TestCordonEndpointRequiresToken(t *testing.T) {
+	b := broker.NewInMemoryBroker()
+	w, err := NewWorker(Config{
+		Broker:      b,
+		Runtime:     &stubRuntime{},
+		Queues:      map[string]int{broker.QUEUE_DEFAULT: 1},
+		CordonToken: "sekret",
+	})
+	assert.NoError(t, err)
+	assert.NoError(t, w.Start())
+
+	// no token -> 401
+	req := httptest.NewRequest(http.MethodPost, "/cordon", nil)
+	rec := httptest.NewRecorder()
+	w.api.server.Handler.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	assert.False(t, w.isCordoned())
+
+	// wrong token -> 401
+	req = httptest.NewRequest(http.MethodPost, "/cordon", nil)
+	req.Header.Set("Authorization", "Bearer wrong")
+	rec = httptest.NewRecorder()
+	w.api.server.Handler.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	assert.False(t, w.isCordoned())
+
+	// correct token -> 200 and worker is cordoned
+	req = httptest.NewRequest(http.MethodPost, "/cordon", nil)
+	req.Header.Set("Authorization", "Bearer sekret")
+	rec = httptest.NewRecorder()
+	w.api.server.Handler.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.True(t, w.isCordoned())
+
+	// uncordon via endpoint
+	req = httptest.NewRequest(http.MethodPost, "/uncordon", nil)
+	req.Header.Set("Authorization", "Bearer sekret")
+	rec = httptest.NewRecorder()
+	w.api.server.Handler.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.False(t, w.isCordoned())
+}
+
+func TestStatusEndpoint(t *testing.T) {
+	b := broker.NewInMemoryBroker()
+	w, err := NewWorker(Config{
+		Broker:  b,
+		Runtime: &stubRuntime{},
+		Queues:  map[string]int{broker.QUEUE_DEFAULT: 1},
+	})
+	assert.NoError(t, err)
+	assert.NoError(t, w.Start())
+
+	get := func() string {
+		req := httptest.NewRequest(http.MethodGet, "/status", nil)
+		rec := httptest.NewRecorder()
+		w.api.server.Handler.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusOK, rec.Code)
+		return rec.Body.String()
+	}
+
+	// status is unauthenticated and reflects cordon state
+	assert.Contains(t, get(), "\"cordoned\":false")
+	assert.Contains(t, get(), "\"taskCount\":0")
+	assert.NoError(t, w.Cordon())
+	assert.Contains(t, get(), "\"cordoned\":true")
+}
+
+func TestCordonedHeartbeatStatus(t *testing.T) {
+	b := broker.NewInMemoryBroker()
+	w, err := NewWorker(Config{
+		Broker:  b,
+		Runtime: &stubRuntime{},
+		Queues:  map[string]int{broker.QUEUE_DEFAULT: 1},
+	})
+	assert.NoError(t, err)
+
+	// nodeStatus is exercised directly (not via the heartbeat loop) so the
+	// test stays deterministic and doesn't race the background goroutine.
+	ctx := context.Background()
+	assert.Equal(t, tork.NodeStatusUP, w.nodeStatus(ctx))
+	assert.NoError(t, w.Cordon())
+	assert.Equal(t, tork.NodeStatusCordoned, w.nodeStatus(ctx))
+	assert.NoError(t, w.Uncordon())
+	assert.Equal(t, tork.NodeStatusUP, w.nodeStatus(ctx))
+
+	// a failing health check takes precedence over cordon
+	assert.NoError(t, w.Cordon())
+	w.runtime.(*stubRuntime).healthErr = errors.New("unhealthy")
+	assert.Equal(t, tork.NodeStatusDown, w.nodeStatus(ctx))
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -34,6 +35,8 @@ type Worker struct {
 	api        *api
 	taskCount  int32
 	middleware []task.MiddlewareFunc
+	mu         sync.Mutex
+	cordoned   bool
 }
 
 type Config struct {
@@ -44,6 +47,8 @@ type Config struct {
 	Queues     map[string]int
 	Limits     Limits
 	Middleware []task.MiddlewareFunc
+	// CordonToken gates the /cordon endpoints; if empty they are disabled.
+	CordonToken string
 }
 
 type Limits struct {
@@ -81,10 +86,10 @@ func NewWorker(cfg Config) (*Worker, error) {
 		queues:     cfg.Queues,
 		tasks:      tasks,
 		limits:     cfg.Limits,
-		api:        newAPI(cfg, tasks),
 		stop:       make(chan any),
 		middleware: cfg.Middleware,
 	}
+	w.api = newAPI(cfg, tasks, w)
 	return w, nil
 }
 
@@ -230,15 +235,24 @@ func (w *Worker) doRunTask(ctx context.Context, t *tork.Task) error {
 	return nil
 }
 
+// nodeStatus reports the status published in heartbeats. DOWN (failed health
+// check) takes precedence over CORDONED so a real fault isn't masked.
+func (w *Worker) nodeStatus(ctx context.Context) tork.NodeStatus {
+	if err := w.runtime.HealthCheck(ctx); err != nil {
+		log.Error().Err(err).Msgf("node %s failed health check", w.id)
+		return tork.NodeStatusDown
+	}
+	if w.isCordoned() {
+		return tork.NodeStatusCordoned
+	}
+	return tork.NodeStatusUP
+}
+
 func (w *Worker) sendHeartbeats() {
 	for {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 		defer cancel()
-		status := tork.NodeStatusUP
-		if err := w.runtime.HealthCheck(ctx); err != nil {
-			log.Error().Err(err).Msgf("node %s failed health check", w.id)
-			status = tork.NodeStatusDown
-		}
+		status := w.nodeStatus(ctx)
 		hostname, err := os.Hostname()
 		if err != nil {
 			log.Error().Err(err).Msgf("failed to get hostname for worker %s", w.id)
@@ -256,7 +270,7 @@ func (w *Worker) sendHeartbeats() {
 				LastHeartbeatAt: time.Now().UTC(),
 				Hostname:        hostname,
 				Port:            w.api.port,
-				TaskCount:       int(atomic.LoadInt32(&w.taskCount)),
+				TaskCount:       w.TaskCount(),
 				Version:         tork.Version,
 			},
 		)
@@ -283,19 +297,72 @@ func (w *Worker) Start() error {
 		return errors.Wrapf(err, "error subscribing for queue: %s", w.id)
 	}
 	// subscribe to shared work queues
+	if err := w.subscribeForWork(); err != nil {
+		return err
+	}
+	go w.sendHeartbeats()
+	return nil
+}
+
+// subscribeForWork subscribes to the shared work queues (startup and uncordon).
+func (w *Worker) subscribeForWork() error {
 	for qname, concurrency := range w.queues {
 		if !broker.IsWorkerQueue(qname) {
 			continue
 		}
 		for i := 0; i < concurrency; i++ {
-			err := w.broker.SubscribeForTasks(qname, w.handleTask)
-			if err != nil {
+			if err := w.broker.SubscribeForTasks(qname, w.handleTask); err != nil {
 				return errors.Wrapf(err, "error subscribing for queue: %s", qname)
 			}
 		}
 	}
-	go w.sendHeartbeats()
 	return nil
+}
+
+// Cordon takes the worker out of rotation: it stops claiming new tasks while
+// running tasks finish normally. Idempotent.
+func (w *Worker) Cordon() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.cordoned {
+		return nil
+	}
+	log.Info().Msgf("cordoning worker %s", w.id)
+	for qname := range w.queues {
+		if !broker.IsWorkerQueue(qname) {
+			continue
+		}
+		if err := w.broker.Unsubscribe(qname); err != nil {
+			return errors.Wrapf(err, "error unsubscribing from queue: %s", qname)
+		}
+	}
+	w.cordoned = true
+	return nil
+}
+
+// Uncordon puts the worker back into rotation. Idempotent.
+func (w *Worker) Uncordon() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if !w.cordoned {
+		return nil
+	}
+	log.Info().Msgf("uncordoning worker %s", w.id)
+	if err := w.subscribeForWork(); err != nil {
+		return err
+	}
+	w.cordoned = false
+	return nil
+}
+
+func (w *Worker) isCordoned() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.cordoned
+}
+
+func (w *Worker) TaskCount() int {
+	return int(atomic.LoadInt32(&w.taskCount))
 }
 
 func (w *Worker) Stop() error {

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -547,8 +547,9 @@ func Test_handleTaskRunTimeoutOK(t *testing.T) {
 }
 
 type stubRuntime struct {
-	result string
-	err    error
+	result    string
+	err       error
+	healthErr error
 }
 
 func (s *stubRuntime) Run(ctx context.Context, t *tork.Task) error {
@@ -560,7 +561,7 @@ func (s *stubRuntime) Run(ctx context.Context, t *tork.Task) error {
 }
 
 func (s *stubRuntime) HealthCheck(ctx context.Context) error {
-	return nil
+	return s.healthErr
 }
 
 func Test_handleTaskRunResultTooLarge(t *testing.T) {

--- a/node.go
+++ b/node.go
@@ -10,9 +10,10 @@ var HEARTBEAT_RATE = time.Second * 30
 type NodeStatus string
 
 const (
-	NodeStatusUP      NodeStatus = "UP"
-	NodeStatusDown    NodeStatus = "DOWN"
-	NodeStatusOffline NodeStatus = "OFFLINE"
+	NodeStatusUP       NodeStatus = "UP"
+	NodeStatusDown     NodeStatus = "DOWN"
+	NodeStatusOffline  NodeStatus = "OFFLINE"
+	NodeStatusCordoned NodeStatus = "CORDONED"
 )
 
 type Node struct {


### PR DESCRIPTION
# feat: worker cordon for graceful node maintenance

## Problem

No way to take a single worker out of rotation without killing it. `Stop()`
tears down the broker after a fixed grace without draining, so a `systemctl
stop` for maintenance orphans in-flight containers and requeues their tasks. The
coordinator has no per-node control, so operators time restarts around a lull by
hand.

## What this adds

Cordon a worker — stop it claiming **new** tasks while running ones finish — and
uncordon it, without restarting. Driven from the worker's own HTTP API, so
cordon authority is the host authority the operator already has.

| Method | Path        | Auth   | Purpose                                     |
|--------|-------------|--------|---------------------------------------------|
| POST   | `/cordon`   | token  | stop claiming new tasks                     |
| POST   | `/uncordon` | token  | resume                                      |
| GET    | `/status`   | none   | `{id, cordoned, taskCount}` for the drain   |

A cordoned worker keeps heartbeating as `CORDONED` (visible in `/nodes`) and
keeps its exclusive queue, so the coordinator can still cancel its tasks.

## How it works

`Cordon()` calls the new `broker.Unsubscribe(qname)` on each shared work queue;
`Uncordon()` re-subscribes. `Unsubscribe` cancels consumers *without* waiting on
in-flight handlers — with prefetch=1 a busy consumer holds one task, stops
taking new work at once, and exits when it acks. So cordon returns promptly
mid-task and interrupts nothing.

## Notes

- `/status` is intentionally unauthenticated (mirrors `/health`; only exposes
  `id`/`cordoned`/`taskCount`).
- Cordon state is in-memory — restart un-cordons. Intended; it's for live
  maintenance, not scheduling policy.
- `done`/`cancel` are now buffered (`rabbitmq.go`) so a non-blocking
  `Unsubscribe` can signal a consumer without leaking its goroutine — touches the
  existing shutdown path.
- In-memory `Unsubscribe` bounds post-cordon delivery to ≤1 task (its `select`
  can take one ready message before seeing the closed terminate channel);
  RabbitMQ stops at the server via `ch.Cancel`.

## Open question: How should `/cordon` be gated?

Current implementation is the least-novel option; the choice is open:

1. **Config token (current)** — `worker.cordon.token`, `/cordon` disabled when unset;
   mirrors `keyauth`. Only as strong as the configured value.
2. **`0600` token file** — authority == permission to read the file == who can
   stop the process. Best fit, but the only runtime file-write in the tree.
3. **Unauthenticated on loopback** — simplest; only ok if any local user
   cordoning is acceptable.